### PR TITLE
Ensure artist metadata saved before assigning quote spotify ids

### DIFF
--- a/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
+++ b/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
@@ -61,8 +61,8 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
             return;
         }
 
-        quoteRepository.assignSpotifyArtistId(artistName, artistMetadata.id());
         saveArtistMetadataIfNotExists(artistMetadata);
+        quoteRepository.assignSpotifyArtistId(artistName, artistMetadata.id());
     }
 
     private SpotifyArtistMetadataEntity createMetadataEntity(Artist artist) throws com.fasterxml.jackson.core.JsonProcessingException {

--- a/src/test/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapterTest.java
+++ b/src/test/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapterTest.java
@@ -1,0 +1,62 @@
+package com.xavelo.sqs.adapter.out.mysql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xavelo.sqs.adapter.out.mysql.spotify.SpotifyArtistMetadataRepository;
+import com.xavelo.sqs.application.domain.Artist;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MysqlAdapterTest {
+
+    @Mock
+    private QuoteRepository quoteRepository;
+
+    @Mock
+    private QuoteMapper quoteMapper;
+
+    @Mock
+    private SpotifyArtistMetadataRepository spotifyArtistMetadataRepository;
+
+    private MysqlAdapter mysqlAdapter;
+
+    @BeforeEach
+    void setUp() {
+        mysqlAdapter = new MysqlAdapter(
+                quoteRepository,
+                quoteMapper,
+                spotifyArtistMetadataRepository,
+                new ObjectMapper()
+        );
+    }
+
+    @Test
+    void syncArtistMetadataSavesMetadataBeforeAssigningQuotes() {
+        Artist artistMetadata = new Artist(
+                "spotify-id",
+                "Artist Name",
+                java.util.List.of("rock"),
+                50,
+                "image",
+                "spotify:url",
+                java.util.List.of()
+        );
+
+        when(spotifyArtistMetadataRepository.existsById("spotify-id")).thenReturn(false);
+
+        mysqlAdapter.syncArtistMetadata("Artist Name", artistMetadata);
+
+        InOrder inOrder = inOrder(spotifyArtistMetadataRepository, quoteRepository);
+        inOrder.verify(spotifyArtistMetadataRepository).existsById("spotify-id");
+        inOrder.verify(spotifyArtistMetadataRepository).save(any());
+        inOrder.verify(quoteRepository).assignSpotifyArtistId("Artist Name", "spotify-id");
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `MysqlAdapter.syncArtistMetadata` saves Spotify artist metadata before assigning the id to quotes
- add a unit test that verifies metadata persistence happens before quote assignment

## Testing
- ./mvnw -q test *(fails: Network is unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d5934d948329894ca2b0176731a8