### PR TITLE
Enhance quote hit metrics

### DIFF
--- a/src/main/java/com/xavelo/sqs/application/service/QuoteService.java
+++ b/src/main/java/com/xavelo/sqs/application/service/QuoteService.java
@@ -117,7 +117,8 @@ public class QuoteService implements StoreQuoteUseCase, GetQuotesUseCase, GetQuo
         Quote quote = loadQuotePort.loadQuote(id);
         if (quote != null) {
             incrementHitsPort.incrementHits(id);
-            metricsPort.incrementHits();
+            metricsPort.incrementTotalHits();
+            metricsPort.incrementQuoteHits(id);
             quote = QuoteHelper.incrementHits(quote);
         }
         return quote;

--- a/src/main/java/com/xavelo/sqs/port/out/MetricsPort.java
+++ b/src/main/java/com/xavelo/sqs/port/out/MetricsPort.java
@@ -5,7 +5,14 @@ package com.xavelo.sqs.port.out;
  */
 public interface MetricsPort {
     /**
-     * Increment the hits counter when a quote is served.
+     * Increment the global hits counter when any quote is served.
      */
-    void incrementHits();
+    void incrementTotalHits();
+
+    /**
+     * Increment the hits counter for a specific quote.
+     *
+     * @param quoteId the identifier of the quote that was served
+     */
+    void incrementQuoteHits(Long quoteId);
 }

--- a/src/test/java/com/xavelo/sqs/application/service/QuoteServiceTest.java
+++ b/src/test/java/com/xavelo/sqs/application/service/QuoteServiceTest.java
@@ -111,7 +111,8 @@ class QuoteServiceTest {
         Quote result = quoteService.getQuote(1L);
 
         verify(incrementHitsPort).incrementHits(1L);
-        verify(metricsPort).incrementHits();
+        verify(metricsPort).incrementTotalHits();
+        verify(metricsPort).incrementQuoteHits(1L);
         assertNotNull(result);
         assertEquals(Integer.valueOf(sampleQuote.hits() + 1), result.hits());
         assertEquals(sampleQuote.posts(), result.posts());


### PR DESCRIPTION
## Summary
- record both global and per-quote hit counters via Micrometer
- publish the enhanced metrics whenever a quote is retrieved

## Testing
- `./mvnw test` *(fails: Maven wrapper cannot download dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d7debd0f8c8329b5749ad1169e8378