### PR TITLE
Generate API DTO jar for application build

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>song-quotes-service-api</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <name>song-quotes-service-api</name>
     <description>Song Quotes Service API definitions and DTOs</description>
@@ -53,6 +53,8 @@
                     <descriptors>
                         <descriptor>src/main/assembly/assembly.xml</descriptor>
                     </descriptors>
+                    <attach>true</attach>
+                    <appendAssemblyId>true</appendAssemblyId>
                 </configuration>
                 <executions>
                     <execution>
@@ -64,7 +66,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
@@ -78,25 +79,28 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <inputSpec>${project.basedir}/src/main/resources/openapi/song-quotes-service.yaml</inputSpec>
-                            <generatorName>spring</generatorName>
-                            <library>spring-boot</library>
+                            <generatorName>java</generatorName>
                             <output>${project.build.directory}/generated-sources</output>
                             <generateApis>false</generateApis>
                             <generateApiTests>false</generateApiTests>
                             <generateModelTests>false</generateModelTests>
                             <generateModelDocumentation>false</generateModelDocumentation>
+                            <generateSupportingFiles>false</generateSupportingFiles>
                             <additionalProperties>
                                 <additionalProperty>modelPackage=com.xavelo.sqs.api.model</additionalProperty>
                                 <additionalProperty>dateLibrary=java8</additionalProperty>
-                                <additionalProperty>useJakartaEe=true</additionalProperty>
                                 <additionalProperty>modelNameSuffix=Dto</additionalProperty>
+                                <additionalProperty>useJakartaEe=true</additionalProperty>
+                                <additionalProperty>serializationLibrary=jackson</additionalProperty>
+                                <additionalProperty>library=resttemplate</additionalProperty>
                             </additionalProperties>
+                            <configOptions>
+                                <sourceFolder>src/main/java</sourceFolder>
+                            </configOptions>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            -->
-            <!--
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -116,7 +120,6 @@
                     </execution>
                 </executions>
             </plugin>
-            -->
         </plugins>
     </build>
 </project>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -17,13 +17,11 @@
     </properties>
 
     <dependencies>
-        <!--
         <dependency>
             <groupId>com.xavelo.sqs</groupId>
             <artifactId>song-quotes-service-api</artifactId>
-            <type>zip</type>
+            <version>${project.version}</version>
         </dependency>
-        -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -158,8 +156,9 @@
                                 <artifactItem>
                                     <artifactId>song-quotes-service-api</artifactId>
                                     <groupId>com.xavelo.sqs</groupId>
-                                    <version>TRUNK-SNAPSHOT</version>
+                                    <version>${project.version}</version>
                                     <type>zip</type>
+                                    <classifier>zip</classifier>
                                     <overWrite>true</overWrite>
                                 </artifactItem>
                             </artifactItems>


### PR DESCRIPTION
## Summary
- generate DTO sources from the OpenAPI spec during the API build and package the module as a jar while still publishing the assembly zip
- consume the generated API jar from the application module and reference the attached zip via the project version

## Testing
- `mvn -B clean package`


------
https://chatgpt.com/codex/tasks/task_e_68d8318a76808329bc3eafa9e7025f0d