### PR TITLE
Fix response handling for missing artists

### DIFF
--- a/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
+++ b/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
@@ -25,7 +25,10 @@ public class ArtistController {
     @GetMapping("/artist/{id}")
     public ResponseEntity<Artist> getArtist(@PathVariable String id) {
         Artist artist = getArtistUseCase.getArtist(id);
-        return artist != null ? ResponseEntity.ok(artist) : ResponseEntity.notFound().build();
+        if (artist == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(artist);
     }
 
     @GetMapping("/artists")


### PR DESCRIPTION
## Summary
- return a 404 response without attempting to cast the ResponseEntity builder
- avoid the ResponseEntity ClassCastException triggered when an artist is not found

## Testing
- ./mvnw -q test *(fails: network is unreachable when downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d84ba2c0e48329893517799107037c