### PR TITLE
Return ArtistDto from artist endpoint

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -188,6 +188,9 @@
                             <generateModelDocumentation>false</generateModelDocumentation>
                             <generateModelTests>false</generateModelTests>
                             <generateSupportingFiles>false</generateSupportingFiles>
+                            <additionalProperties>
+                                <additionalProperty>modelNameSuffix=Dto</additionalProperty>
+                            </additionalProperties>
                             <configOptions>
                                 <interfaceOnly>true</interfaceOnly>
                                 <skipDefaultInterface>true</skipDefaultInterface>

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
@@ -1,10 +1,11 @@
 package com.xavelo.sqs.adapter.in.http.artist;
 
 import com.xavelo.sqs.adapter.in.http.artist.mapper.ArtistMapper;
-import com.xavelo.sqs.api.model.ArtistQuoteCountDto;
 import com.xavelo.sqs.application.api.DefaultApi;
-import com.xavelo.sqs.application.api.model.ArtistQuoteCount;
+import com.xavelo.sqs.application.api.model.ArtistDto;
+import com.xavelo.sqs.application.api.model.ArtistQuoteCountDto;
 import com.xavelo.sqs.application.domain.Artist;
+import com.xavelo.sqs.application.domain.ArtistQuoteCount;
 import com.xavelo.sqs.port.in.GetArtistQuoteCountsUseCase;
 import com.xavelo.sqs.port.in.GetArtistUseCase;
 import org.springframework.http.ResponseEntity;
@@ -30,20 +31,16 @@ public class ArtistController implements DefaultApi {
     }
 
     @Override
-    public ResponseEntity<com.xavelo.sqs.application.api.model.Artist> getArtist(@PathVariable String id) {
+    public ResponseEntity<ArtistDto> getArtist(@PathVariable String id) {
         Artist artist = getArtistUseCase.getArtist(id);
-        return artist != null ? (ResponseEntity<com.xavelo.sqs.application.api.model.Artist>) ResponseEntity.ok() : ResponseEntity.notFound().build();
+        return artist != null
+                ? ResponseEntity.ok(artistMapper.toDto(artist))
+                : ResponseEntity.notFound().build();
     }
 
-    @Override
-    public ResponseEntity<List<ArtistQuoteCount>> getArtists() {
-        return null;
-    }
-
-    /*
     @Override
     public ResponseEntity<List<ArtistQuoteCountDto>> getArtists() {
         List<ArtistQuoteCount> artists = getArtistQuoteCountsUseCase.getArtistQuoteCounts();
-        return ResponseEntity.ok(artistMapper.toQuoteCountsModel(artists));
-    }*/
+        return ResponseEntity.ok(artistMapper.toQuoteCountDtos(artists));
+    }
 }

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/mapper/ArtistMapper.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/mapper/ArtistMapper.java
@@ -1,8 +1,8 @@
 package com.xavelo.sqs.adapter.in.http.artist.mapper;
 
-import com.xavelo.sqs.api.model.ArtistDto;
-import com.xavelo.sqs.api.model.ArtistQuoteCountDto;
-import com.xavelo.sqs.api.model.ArtistTrackDto;
+import com.xavelo.sqs.application.api.model.ArtistDto;
+import com.xavelo.sqs.application.api.model.ArtistQuoteCountDto;
+import com.xavelo.sqs.application.api.model.ArtistTrackDto;
 import com.xavelo.sqs.application.domain.Artist;
 import com.xavelo.sqs.application.domain.ArtistQuoteCount;
 import org.mapstruct.Mapper;
@@ -19,6 +19,4 @@ public interface ArtistMapper {
     ArtistQuoteCountDto toQuoteCountDto(ArtistQuoteCount artistQuoteCount);
 
     List<ArtistQuoteCountDto> toQuoteCountDtos(List<ArtistQuoteCount> artists);
-
-    List<ArtistQuoteCountDto> toQuoteCountsModel(List<com.xavelo.sqs.application.domain.ArtistQuoteCount> artists);
 }

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/mapper/ArtistMapper.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/mapper/ArtistMapper.java
@@ -6,6 +6,7 @@ import com.xavelo.sqs.application.api.model.ArtistTrackDto;
 import com.xavelo.sqs.application.domain.Artist;
 import com.xavelo.sqs.application.domain.ArtistQuoteCount;
 import org.mapstruct.Mapper;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import java.util.List;
 
@@ -19,4 +20,8 @@ public interface ArtistMapper {
     ArtistQuoteCountDto toQuoteCountDto(ArtistQuoteCount artistQuoteCount);
 
     List<ArtistQuoteCountDto> toQuoteCountDtos(List<ArtistQuoteCount> artists);
+
+    default JsonNullable<String> map(String value) {
+        return value == null ? JsonNullable.undefined() : JsonNullable.of(value);
+    }
 }


### PR DESCRIPTION
## Summary
- configure the application OpenAPI generator to suffix models with Dto so generated types match the expected contract
- map artist responses to the generated ArtistDto and expose quote counts as DTOs from the controller

## Testing
- not run (build requires network access that is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d851589e808329af5f17a09249d55f