### PR TITLE
Configure Artist API interface generation

### DIFF
--- a/api/src/main/resources/openapi/song-quotes-service.yaml
+++ b/api/src/main/resources/openapi/song-quotes-service.yaml
@@ -9,6 +9,8 @@ servers:
 paths:
   /artist/{id}:
     get:
+      tags:
+        - Artist
       summary: Get artist details
       operationId: getArtist
       parameters:
@@ -28,6 +30,8 @@ paths:
           description: Artist not found
   /artists:
     get:
+      tags:
+        - Artist
       summary: Get artists with quote counts
       operationId: getArtists
       responses:

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
@@ -1,7 +1,7 @@
 package com.xavelo.sqs.adapter.in.http.artist;
 
 import com.xavelo.sqs.adapter.in.http.artist.mapper.ArtistMapper;
-import com.xavelo.sqs.application.api.DefaultApi;
+import com.xavelo.sqs.application.api.ArtistApi;
 import com.xavelo.sqs.application.api.model.ArtistDto;
 import com.xavelo.sqs.application.api.model.ArtistQuoteCountDto;
 import com.xavelo.sqs.application.domain.Artist;
@@ -17,7 +17,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api")
-public class ArtistController implements DefaultApi {
+public class ArtistController implements ArtistApi {
 
     private final GetArtistUseCase getArtistUseCase;
     private final GetArtistQuoteCountsUseCase getArtistQuoteCountsUseCase;


### PR DESCRIPTION
## Summary
- tag the artist endpoints in the OpenAPI definition so the generated interface is named `ArtistApi`
- adjust the artist controller to implement the new `ArtistApi` interface

## Testing
- `./mvnw -pl application compile` *(fails: network is unreachable when downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d8572c735c8329bd9d167c4475ca55