### PR TITLE
Implement QuoteApi mappings for quote endpoints

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -59,7 +59,7 @@
                 <executions>
                     <execution>
                         <id>create-archive</id>
-                        <phase>package</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/api/src/main/resources/openapi/song-quotes-service.yaml
+++ b/api/src/main/resources/openapi/song-quotes-service.yaml
@@ -43,6 +43,87 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ArtistQuoteCount'
+  /quotes:
+    get:
+      tags:
+        - Quote
+      summary: Get all quotes
+      operationId: getQuotes
+      responses:
+        '200':
+          description: List of quotes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Quote'
+  /quotes/count:
+    get:
+      tags:
+        - Quote
+      summary: Get total number of quotes
+      operationId: getQuotesCount
+      responses:
+        '200':
+          description: Total number of quotes
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: int64
+  /quote/random:
+    get:
+      tags:
+        - Quote
+      summary: Get a random quote
+      operationId: getRandomQuote
+      responses:
+        '200':
+          description: Random quote found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Quote'
+        '404':
+          description: No quote found
+  /quote/{id}:
+    get:
+      tags:
+        - Quote
+      summary: Get a quote by identifier
+      operationId: getQuote
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Quote found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Quote'
+        '404':
+          description: Quote not found
+  /quotes/top10:
+    get:
+      tags:
+        - Quote
+      summary: Get the ten most popular quotes
+      operationId: getTop10Quotes
+      responses:
+        '200':
+          description: List of top quotes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Quote'
   /admin/quote:
     post:
       tags:

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
@@ -1,63 +1,77 @@
 package com.xavelo.sqs.adapter.in.http.quote;
 
+import com.xavelo.sqs.adapter.in.http.quote.mapper.QuoteMapper;
+import com.xavelo.sqs.application.api.QuoteApi;
+import com.xavelo.sqs.application.api.model.QuoteDto;
 import com.xavelo.sqs.application.domain.Quote;
-import com.xavelo.sqs.port.in.*;
+import com.xavelo.sqs.port.in.CountQuotesUseCase;
+import com.xavelo.sqs.port.in.GetQuoteUseCase;
+import com.xavelo.sqs.port.in.GetQuotesUseCase;
+import com.xavelo.sqs.port.in.GetRandomQuoteUseCase;
+import com.xavelo.sqs.port.in.GetTop10QuotesUseCase;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
-public class QuoteController {
+public class QuoteController implements QuoteApi {
 
     private final GetQuotesUseCase getQuotesUseCase;
     private final GetQuoteUseCase getQuoteUseCase;
     private final GetRandomQuoteUseCase getRandomQuoteUseCase;
     private final CountQuotesUseCase countQuotesUseCase;
     private final GetTop10QuotesUseCase getTop10QuotesUseCase;
+    private final QuoteMapper quoteMapper;
 
     public QuoteController(GetQuotesUseCase getQuotesUseCase,
                            GetQuoteUseCase getQuoteUseCase,
                            CountQuotesUseCase countQuotesUseCase,
                            GetRandomQuoteUseCase getRandomQuoteUseCase,
-                           GetTop10QuotesUseCase getTop10QuotesUseCase) {
+                           GetTop10QuotesUseCase getTop10QuotesUseCase,
+                           QuoteMapper quoteMapper) {
         this.getQuotesUseCase = getQuotesUseCase;
         this.getQuoteUseCase = getQuoteUseCase;
         this.getRandomQuoteUseCase = getRandomQuoteUseCase;
         this.countQuotesUseCase = countQuotesUseCase;
         this.getTop10QuotesUseCase = getTop10QuotesUseCase;
+        this.quoteMapper = quoteMapper;
     }
 
-    @GetMapping("/quotes")
-    public ResponseEntity<java.util.List<Quote>> getQuotes() {
-        java.util.List<Quote> quotes = getQuotesUseCase.getQuotes();
-        return ResponseEntity.ok(quotes);
+    @Override
+    public ResponseEntity<List<QuoteDto>> getQuotes() {
+        List<Quote> quotes = getQuotesUseCase.getQuotes();
+        return ResponseEntity.ok(quoteMapper.toDtos(quotes));
     }
 
-    @GetMapping("/quotes/count")
+    @Override
     public ResponseEntity<Long> getQuotesCount() {
         Long count = countQuotesUseCase.countQuotes();
         return ResponseEntity.ok(count);
     }
 
-    @GetMapping("/quote/random")
-    public ResponseEntity<Quote> getRandomQuote() {
+    @Override
+    public ResponseEntity<QuoteDto> getRandomQuote() {
         Quote quote = getRandomQuoteUseCase.getRandomQuote();
-        return quote != null ? ResponseEntity.ok(quote) : ResponseEntity.notFound().build();
+        return quote != null
+                ? ResponseEntity.ok(quoteMapper.toDto(quote))
+                : ResponseEntity.notFound().build();
     }
 
-    @GetMapping("/quote/{id}")
-    public ResponseEntity<Quote> getQuote(@PathVariable Long id) {
+    @Override
+    public ResponseEntity<QuoteDto> getQuote(@PathVariable("id") Long id) {
         Quote quote = getQuoteUseCase.getQuote(id);
-        return quote != null ? ResponseEntity.ok(quote) : ResponseEntity.notFound().build();
+        return quote != null
+                ? ResponseEntity.ok(quoteMapper.toDto(quote))
+                : ResponseEntity.notFound().build();
     }
 
-    @GetMapping("/quotes/top10")
-    public ResponseEntity<java.util.List<Quote>> getTop10Quotes() {
-        java.util.List<Quote> quotes = getTop10QuotesUseCase.getTop10Quotes();
-        return ResponseEntity.ok(quotes);
+    @Override
+    public ResponseEntity<List<QuoteDto>> getTop10Quotes() {
+        List<Quote> quotes = getTop10QuotesUseCase.getTop10Quotes();
+        return ResponseEntity.ok(quoteMapper.toDtos(quotes));
     }
 }

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/mapper/QuoteMapper.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/mapper/QuoteMapper.java
@@ -6,7 +6,7 @@ import org.mapstruct.Mapper;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", implementationName = "QuoteHttpMapperImpl")
 public interface QuoteMapper {
 
     QuoteDto toDto(Quote quote);

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/mapper/QuoteMapper.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/mapper/QuoteMapper.java
@@ -1,0 +1,15 @@
+package com.xavelo.sqs.adapter.in.http.quote.mapper;
+
+import com.xavelo.sqs.application.api.model.QuoteDto;
+import com.xavelo.sqs.application.domain.Quote;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface QuoteMapper {
+
+    QuoteDto toDto(Quote quote);
+
+    List<QuoteDto> toDtos(List<Quote> quotes);
+}

--- a/application/src/test/java/com/xavelo/sqs/adapter/in/http/quote/QuoteControllerTest.java
+++ b/application/src/test/java/com/xavelo/sqs/adapter/in/http/quote/QuoteControllerTest.java
@@ -1,6 +1,8 @@
 package com.xavelo.sqs.adapter.in.http.quote;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xavelo.sqs.adapter.in.http.quote.mapper.QuoteMapper;
+import com.xavelo.sqs.application.api.model.QuoteDto;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.in.*;
 import org.junit.jupiter.api.Test;
@@ -32,15 +34,27 @@ class QuoteControllerTest {
     @MockBean private DeleteQuoteUseCase deleteQuoteUseCase;
     @MockBean private UpdateQuoteUseCase updateQuoteUseCase;
     @MockBean private GetTop10QuotesUseCase getTop10QuotesUseCase;
+    @MockBean private QuoteMapper quoteMapper;
 
     @Test
     void getQuotes() throws Exception {
         List<Quote> quotes = List.of(new Quote(1L, "q", "s", "a", 1999, "art", 0, 0, null));
+        List<QuoteDto> dtos = List.of(new QuoteDto()
+                .id(1L)
+                .quote("q")
+                .song("s")
+                .album("a")
+                .year(1999)
+                .artist("art")
+                .posts(0)
+                .hits(0)
+                .spotifyArtistId(null));
         when(getQuotesUseCase.getQuotes()).thenReturn(quotes);
+        when(quoteMapper.toDtos(quotes)).thenReturn(dtos);
 
         mockMvc.perform(get("/api/quotes"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(quotes)));
+                .andExpect(content().json(objectMapper.writeValueAsString(dtos)));
     }
 
     @Test
@@ -55,21 +69,43 @@ class QuoteControllerTest {
     @Test
     void getRandomQuoteFound() throws Exception {
         Quote quote = new Quote(1L, "q", "s", "a", 1999, "art", 0, 0, null);
+        QuoteDto dto = new QuoteDto()
+                .id(1L)
+                .quote("q")
+                .song("s")
+                .album("a")
+                .year(1999)
+                .artist("art")
+                .posts(0)
+                .hits(0)
+                .spotifyArtistId(null);
         when(getRandomQuoteUseCase.getRandomQuote()).thenReturn(quote);
+        when(quoteMapper.toDto(quote)).thenReturn(dto);
 
         mockMvc.perform(get("/api/quote/random"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(quote)));
+                .andExpect(content().json(objectMapper.writeValueAsString(dto)));
     }
 
     @Test
     void getQuoteFound() throws Exception {
         Quote quote = new Quote(1L, "q", "s", "a", 1999, "art", 0, 0, null);
+        QuoteDto dto = new QuoteDto()
+                .id(1L)
+                .quote("q")
+                .song("s")
+                .album("a")
+                .year(1999)
+                .artist("art")
+                .posts(0)
+                .hits(0)
+                .spotifyArtistId(null);
         when(getQuoteUseCase.getQuote(1L)).thenReturn(quote);
+        when(quoteMapper.toDto(quote)).thenReturn(dto);
 
         mockMvc.perform(get("/api/quote/1"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(quote)));
+                .andExpect(content().json(objectMapper.writeValueAsString(dto)));
     }
 
     @Test
@@ -86,10 +122,33 @@ class QuoteControllerTest {
                 new Quote(1L, "q1", "s1", "a1", 2000, "art1", 100, 10, null),
                 new Quote(2L, "q2", "s2", "a2", 2001, "art2", 90, 9, null)
         );
+        List<QuoteDto> dtos = List.of(
+                new QuoteDto()
+                        .id(1L)
+                        .quote("q1")
+                        .song("s1")
+                        .album("a1")
+                        .year(2000)
+                        .artist("art1")
+                        .posts(100)
+                        .hits(10)
+                        .spotifyArtistId(null),
+                new QuoteDto()
+                        .id(2L)
+                        .quote("q2")
+                        .song("s2")
+                        .album("a2")
+                        .year(2001)
+                        .artist("art2")
+                        .posts(90)
+                        .hits(9)
+                        .spotifyArtistId(null)
+        );
         when(getTop10QuotesUseCase.getTop10Quotes()).thenReturn(quotes);
+        when(quoteMapper.toDtos(quotes)).thenReturn(dtos);
 
         mockMvc.perform(get("/api/quotes/top10"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(quotes)));
+                .andExpect(content().json(objectMapper.writeValueAsString(dtos)));
     }
 }


### PR DESCRIPTION
## Summary
- add quote-related paths to the OpenAPI document so QuoteApi is generated
- adapt the quote HTTP controller to implement QuoteApi using a dedicated QuoteMapper
- provide the mapper and refresh the controller tests to work with generated DTOs

## Testing
- mvn -pl application -am test *(fails: maven-dependency-plugin cannot resolve com.xavelo.sqs:song-quotes-service-api:zip:zip:TRUNK-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68d85ac2ffa883298aa2c3862fd6f62f