### PR TITLE
Split OpenAPI specification into per-API documents

### DIFF
--- a/api/src/main/resources/openapi/admin-api.yaml
+++ b/api/src/main/resources/openapi/admin-api.yaml
@@ -1,0 +1,120 @@
+openapi: 3.0.3
+info:
+  title: Song Quotes Admin API
+  version: 1.0.0
+  description: Administrative endpoints for managing quotes.
+servers:
+  - url: /
+tags:
+  - name: Admin
+    description: Administrative quote management operations.
+paths:
+  /admin/quote:
+    post:
+      tags:
+        - Admin
+      summary: Create a new quote
+      operationId: createQuote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Quote'
+      responses:
+        '200':
+          description: Quote successfully created
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: int64
+  /admin/quotes:
+    post:
+      tags:
+        - Admin
+      summary: Create multiple quotes
+      operationId: createQuotes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Quote'
+      responses:
+        '200':
+          description: Quotes successfully created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: int64
+  /admin/quote/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+    delete:
+      tags:
+        - Admin
+      summary: Delete an existing quote
+      operationId: deleteQuote
+      responses:
+        '204':
+          description: Quote successfully deleted
+    put:
+      tags:
+        - Admin
+      summary: Replace an existing quote
+      operationId: updateQuote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Quote'
+      responses:
+        '204':
+          description: Quote successfully updated
+        '400':
+          description: Quote contains restricted fields
+    patch:
+      tags:
+        - Admin
+      summary: Partially update an existing quote
+      operationId: patchQuote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Quote'
+      responses:
+        '204':
+          description: Quote successfully updated
+        '400':
+          description: Quote contains restricted fields
+  /admin/export:
+    get:
+      tags:
+        - Admin
+      summary: Export all quotes as SQL statements
+      operationId: exportQuotes
+      responses:
+        '200':
+          description: SQL export of all quotes
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    Quote:
+      $ref: './components/schemas.yaml#/Quote'

--- a/api/src/main/resources/openapi/admin-api.yaml
+++ b/api/src/main/resources/openapi/admin-api.yaml
@@ -20,7 +20,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Quote'
+              $ref: './components/schemas.yaml#/components/schemas/Quote'
       responses:
         '200':
           description: Quote successfully created
@@ -42,7 +42,7 @@ paths:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/Quote'
+                $ref: './components/schemas.yaml#/components/schemas/Quote'
       responses:
         '200':
           description: Quotes successfully created
@@ -79,7 +79,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Quote'
+              $ref: './components/schemas.yaml#/components/schemas/Quote'
       responses:
         '204':
           description: Quote successfully updated
@@ -95,7 +95,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Quote'
+              $ref: './components/schemas.yaml#/components/schemas/Quote'
       responses:
         '204':
           description: Quote successfully updated
@@ -117,4 +117,4 @@ paths:
 components:
   schemas:
     Quote:
-      $ref: './components/schemas.yaml#/Quote'
+      $ref: './components/schemas.yaml#/components/schemas/Quote'

--- a/api/src/main/resources/openapi/artist-api.yaml
+++ b/api/src/main/resources/openapi/artist-api.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.3
+info:
+  title: Song Quotes Artist API
+  version: 1.0.0
+  description: Artist discovery endpoints for the Song Quotes Service.
+servers:
+  - url: /api
+tags:
+  - name: Artist
+    description: Artist information and quote statistics.
+paths:
+  /artist/{id}:
+    get:
+      tags:
+        - Artist
+      summary: Get artist details
+      operationId: getArtist
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Artist found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Artist'
+        '404':
+          description: Artist not found
+  /artists:
+    get:
+      tags:
+        - Artist
+      summary: Get artists with quote counts
+      operationId: getArtists
+      responses:
+        '200':
+          description: List of artists
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ArtistQuoteCount'
+components:
+  schemas:
+    Artist:
+      $ref: './components/schemas.yaml#/Artist'
+    ArtistTrack:
+      $ref: './components/schemas.yaml#/ArtistTrack'
+    ArtistQuoteCount:
+      $ref: './components/schemas.yaml#/ArtistQuoteCount'

--- a/api/src/main/resources/openapi/artist-api.yaml
+++ b/api/src/main/resources/openapi/artist-api.yaml
@@ -27,7 +27,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Artist'
+                $ref: './components/schemas.yaml#/components/schemas/Artist'
         '404':
           description: Artist not found
   /artists:
@@ -44,12 +44,12 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ArtistQuoteCount'
+                  $ref: './components/schemas.yaml#/components/schemas/ArtistQuoteCount'
 components:
   schemas:
     Artist:
-      $ref: './components/schemas.yaml#/Artist'
+      $ref: './components/schemas.yaml#/components/schemas/Artist'
     ArtistTrack:
-      $ref: './components/schemas.yaml#/ArtistTrack'
+      $ref: './components/schemas.yaml#/components/schemas/ArtistTrack'
     ArtistQuoteCount:
-      $ref: './components/schemas.yaml#/ArtistQuoteCount'
+      $ref: './components/schemas.yaml#/components/schemas/ArtistQuoteCount'

--- a/api/src/main/resources/openapi/components/schemas.yaml
+++ b/api/src/main/resources/openapi/components/schemas.yaml
@@ -1,0 +1,103 @@
+Quote:
+  type: object
+  properties:
+    id:
+      type: integer
+      format: int64
+      description: Identifier of the quote
+    quote:
+      type: string
+      description: Text content of the quote
+    song:
+      type: string
+      description: Name of the song the quote belongs to
+    album:
+      type: string
+      description: Album that contains the song
+    year:
+      type: integer
+      format: int32
+      description: Release year of the song
+    artist:
+      type: string
+      description: Artist attributed to the quote
+    posts:
+      type: integer
+      format: int32
+      description: Number of times the quote has been posted
+    hits:
+      type: integer
+      format: int32
+      description: Number of times the quote has been viewed
+    spotifyArtistId:
+      type: string
+      description: Spotify identifier of the artist
+Artist:
+  type: object
+  required:
+    - id
+    - name
+    - genres
+    - popularity
+    - spotifyUrl
+    - topTracks
+  properties:
+    id:
+      type: string
+      description: Spotify identifier of the artist
+    name:
+      type: string
+      description: Name of the artist
+    genres:
+      type: array
+      description: Genres associated with the artist
+      items:
+        type: string
+    popularity:
+      type: integer
+      format: int32
+      description: Popularity score assigned by Spotify
+    imageUrl:
+      type: string
+      description: URL pointing to an image of the artist
+    spotifyUrl:
+      type: string
+      description: Spotify URL of the artist
+    topTracks:
+      type: array
+      description: Top Spotify tracks for the artist
+      items:
+        $ref: '#/ArtistTrack'
+ArtistTrack:
+  type: object
+  required:
+    - id
+    - name
+  properties:
+    id:
+      type: string
+      description: Spotify identifier of the track
+    name:
+      type: string
+      description: Track name
+    previewUrl:
+      type: string
+      nullable: true
+      description: Preview URL for the track
+ArtistQuoteCount:
+  type: object
+  required:
+    - id
+    - artist
+    - quotes
+  properties:
+    id:
+      type: string
+      description: Spotify identifier of the artist
+    artist:
+      type: string
+      description: Name of the artist
+    quotes:
+      type: integer
+      format: int64
+      description: Number of quotes stored for the artist

--- a/api/src/main/resources/openapi/components/schemas.yaml
+++ b/api/src/main/resources/openapi/components/schemas.yaml
@@ -1,103 +1,105 @@
-Quote:
-  type: object
-  properties:
-    id:
-      type: integer
-      format: int64
-      description: Identifier of the quote
-    quote:
-      type: string
-      description: Text content of the quote
-    song:
-      type: string
-      description: Name of the song the quote belongs to
-    album:
-      type: string
-      description: Album that contains the song
-    year:
-      type: integer
-      format: int32
-      description: Release year of the song
-    artist:
-      type: string
-      description: Artist attributed to the quote
-    posts:
-      type: integer
-      format: int32
-      description: Number of times the quote has been posted
-    hits:
-      type: integer
-      format: int32
-      description: Number of times the quote has been viewed
-    spotifyArtistId:
-      type: string
-      description: Spotify identifier of the artist
-Artist:
-  type: object
-  required:
-    - id
-    - name
-    - genres
-    - popularity
-    - spotifyUrl
-    - topTracks
-  properties:
-    id:
-      type: string
-      description: Spotify identifier of the artist
-    name:
-      type: string
-      description: Name of the artist
-    genres:
-      type: array
-      description: Genres associated with the artist
-      items:
-        type: string
-    popularity:
-      type: integer
-      format: int32
-      description: Popularity score assigned by Spotify
-    imageUrl:
-      type: string
-      description: URL pointing to an image of the artist
-    spotifyUrl:
-      type: string
-      description: Spotify URL of the artist
-    topTracks:
-      type: array
-      description: Top Spotify tracks for the artist
-      items:
-        $ref: '#/ArtistTrack'
-ArtistTrack:
-  type: object
-  required:
-    - id
-    - name
-  properties:
-    id:
-      type: string
-      description: Spotify identifier of the track
-    name:
-      type: string
-      description: Track name
-    previewUrl:
-      type: string
-      nullable: true
-      description: Preview URL for the track
-ArtistQuoteCount:
-  type: object
-  required:
-    - id
-    - artist
-    - quotes
-  properties:
-    id:
-      type: string
-      description: Spotify identifier of the artist
-    artist:
-      type: string
-      description: Name of the artist
-    quotes:
-      type: integer
-      format: int64
-      description: Number of quotes stored for the artist
+components:
+  schemas:
+    Quote:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Identifier of the quote
+        quote:
+          type: string
+          description: Text content of the quote
+        song:
+          type: string
+          description: Name of the song the quote belongs to
+        album:
+          type: string
+          description: Album that contains the song
+        year:
+          type: integer
+          format: int32
+          description: Release year of the song
+        artist:
+          type: string
+          description: Artist attributed to the quote
+        posts:
+          type: integer
+          format: int32
+          description: Number of times the quote has been posted
+        hits:
+          type: integer
+          format: int32
+          description: Number of times the quote has been viewed
+        spotifyArtistId:
+          type: string
+          description: Spotify identifier of the artist
+    Artist:
+      type: object
+      required:
+        - id
+        - name
+        - genres
+        - popularity
+        - spotifyUrl
+        - topTracks
+      properties:
+        id:
+          type: string
+          description: Spotify identifier of the artist
+        name:
+          type: string
+          description: Name of the artist
+        genres:
+          type: array
+          description: Genres associated with the artist
+          items:
+            type: string
+        popularity:
+          type: integer
+          format: int32
+          description: Popularity score assigned by Spotify
+        imageUrl:
+          type: string
+          description: URL pointing to an image of the artist
+        spotifyUrl:
+          type: string
+          description: Spotify URL of the artist
+        topTracks:
+          type: array
+          description: Top Spotify tracks for the artist
+          items:
+            $ref: '#/components/schemas/ArtistTrack'
+    ArtistTrack:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          description: Spotify identifier of the track
+        name:
+          type: string
+          description: Track name
+        previewUrl:
+          type: string
+          nullable: true
+          description: Preview URL for the track
+    ArtistQuoteCount:
+      type: object
+      required:
+        - id
+        - artist
+        - quotes
+      properties:
+        id:
+          type: string
+          description: Spotify identifier of the artist
+        artist:
+          type: string
+          description: Name of the artist
+        quotes:
+          type: integer
+          format: int64
+          description: Number of quotes stored for the artist

--- a/api/src/main/resources/openapi/ping-api.yaml
+++ b/api/src/main/resources/openapi/ping-api.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: Song Quotes Ping API
+  version: 1.0.0
+  description: Health check endpoints.
+servers:
+  - url: /api
+tags:
+  - name: Ping
+    description: Health check endpoints.
+paths:
+  /ping:
+    get:
+      tags:
+        - Ping
+      summary: Ping the service
+      operationId: ping
+      responses:
+        '200':
+          description: Successful ping
+          content:
+            text/plain:
+              schema:
+                type: string
+  /secure/ping:
+    get:
+      tags:
+        - Ping
+      summary: Ping the service via the secured endpoint
+      operationId: securePing
+      responses:
+        '200':
+          description: Successful ping
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/api/src/main/resources/openapi/quote-api.yaml
+++ b/api/src/main/resources/openapi/quote-api.yaml
@@ -23,7 +23,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Quote'
+                  $ref: './components/schemas.yaml#/components/schemas/Quote'
   /quotes/count:
     get:
       tags:
@@ -50,7 +50,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Quote'
+                $ref: './components/schemas.yaml#/components/schemas/Quote'
         '404':
           description: No quote available
   /quote/{id}:
@@ -72,7 +72,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Quote'
+                $ref: './components/schemas.yaml#/components/schemas/Quote'
         '404':
           description: Quote not found
   /quotes/top10:
@@ -89,8 +89,8 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Quote'
+                  $ref: './components/schemas.yaml#/components/schemas/Quote'
 components:
   schemas:
     Quote:
-      $ref: './components/schemas.yaml#/Quote'
+      $ref: './components/schemas.yaml#/components/schemas/Quote'

--- a/api/src/main/resources/openapi/quote-api.yaml
+++ b/api/src/main/resources/openapi/quote-api.yaml
@@ -1,0 +1,96 @@
+openapi: 3.0.3
+info:
+  title: Song Quotes Public Quote API
+  version: 1.0.0
+  description: Public endpoints for retrieving quotes.
+servers:
+  - url: /api
+tags:
+  - name: Quote
+    description: Quote retrieval operations.
+paths:
+  /quotes:
+    get:
+      tags:
+        - Quote
+      summary: Get quotes
+      operationId: getQuotes
+      responses:
+        '200':
+          description: List of quotes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Quote'
+  /quotes/count:
+    get:
+      tags:
+        - Quote
+      summary: Get number of quotes
+      operationId: getQuotesCount
+      responses:
+        '200':
+          description: Number of quotes available
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: int64
+  /quote/random:
+    get:
+      tags:
+        - Quote
+      summary: Get a random quote
+      operationId: getRandomQuote
+      responses:
+        '200':
+          description: Random quote found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Quote'
+        '404':
+          description: No quote available
+  /quote/{id}:
+    get:
+      tags:
+        - Quote
+      summary: Get quote by identifier
+      operationId: getQuote
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Quote found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Quote'
+        '404':
+          description: Quote not found
+  /quotes/top10:
+    get:
+      tags:
+        - Quote
+      summary: Get top 10 quotes
+      operationId: getTop10Quotes
+      responses:
+        '200':
+          description: Top quotes ranked by popularity
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Quote'
+components:
+  schemas:
+    Quote:
+      $ref: './components/schemas.yaml#/Quote'

--- a/api/src/main/resources/openapi/song-quotes-service.yaml
+++ b/api/src/main/resources/openapi/song-quotes-service.yaml
@@ -36,10 +36,10 @@ paths:
 components:
   schemas:
     Quote:
-      $ref: './components/schemas.yaml#/Quote'
+      $ref: './components/schemas.yaml#/components/schemas/Quote'
     Artist:
-      $ref: './components/schemas.yaml#/Artist'
+      $ref: './components/schemas.yaml#/components/schemas/Artist'
     ArtistTrack:
-      $ref: './components/schemas.yaml#/ArtistTrack'
+      $ref: './components/schemas.yaml#/components/schemas/ArtistTrack'
     ArtistQuoteCount:
-      $ref: './components/schemas.yaml#/ArtistQuoteCount'
+      $ref: './components/schemas.yaml#/components/schemas/ArtistQuoteCount'

--- a/api/src/main/resources/openapi/song-quotes-service.yaml
+++ b/api/src/main/resources/openapi/song-quotes-service.yaml
@@ -2,268 +2,44 @@ openapi: 3.0.3
 info:
   title: Song Quotes Service API
   version: 1.0.0
-  description: |
-    OpenAPI definition for the Song Quotes Service artist endpoints.
+  description: Aggregated OpenAPI definition for the Song Quotes Service endpoints.
 servers:
   - url: /api
+  - url: /
 paths:
   /artist/{id}:
-    get:
-      tags:
-        - Artist
-      summary: Get artist details
-      operationId: getArtist
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Artist found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Artist'
-        '404':
-          description: Artist not found
+    $ref: './artist-api.yaml#/paths/~1artist~1{id}'
   /artists:
-    get:
-      tags:
-        - Artist
-      summary: Get artists with quote counts
-      operationId: getArtists
-      responses:
-        '200':
-          description: List of artists
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ArtistQuoteCount'
+    $ref: './artist-api.yaml#/paths/~1artists'
   /admin/quote:
-    post:
-      tags:
-        - Admin
-      summary: Create a new quote
-      operationId: createQuote
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Quote'
-      responses:
-        '200':
-          description: Quote successfully created
-          content:
-            application/json:
-              schema:
-                type: integer
-                format: int64
+    $ref: './admin-api.yaml#/paths/~1admin~1quote'
   /admin/quotes:
-    post:
-      tags:
-        - Admin
-      summary: Create multiple quotes
-      operationId: createQuotes
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/Quote'
-      responses:
-        '200':
-          description: Quotes successfully created
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: integer
-                  format: int64
+    $ref: './admin-api.yaml#/paths/~1admin~1quotes'
   /admin/quote/{id}:
-    delete:
-      tags:
-        - Admin
-      summary: Delete an existing quote
-      operationId: deleteQuote
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
-      responses:
-        '204':
-          description: Quote successfully deleted
-    put:
-      tags:
-        - Admin
-      summary: Replace an existing quote
-      operationId: updateQuote
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Quote'
-      responses:
-        '204':
-          description: Quote successfully updated
-        '400':
-          description: Quote contains restricted fields
-    patch:
-      tags:
-        - Admin
-      summary: Partially update an existing quote
-      operationId: patchQuote
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Quote'
-      responses:
-        '204':
-          description: Quote successfully updated
-        '400':
-          description: Quote contains restricted fields
+    $ref: './admin-api.yaml#/paths/~1admin~1quote~1{id}'
   /admin/export:
-    get:
-      tags:
-        - Admin
-      summary: Export all quotes as SQL statements
-      operationId: exportQuotes
-      responses:
-        '200':
-          description: SQL export of all quotes
-          content:
-            text/plain:
-              schema:
-                type: string
+    $ref: './admin-api.yaml#/paths/~1admin~1export'
+  /quotes:
+    $ref: './quote-api.yaml#/paths/~1quotes'
+  /quotes/count:
+    $ref: './quote-api.yaml#/paths/~1quotes~1count'
+  /quote/random:
+    $ref: './quote-api.yaml#/paths/~1quote~1random'
+  /quote/{id}:
+    $ref: './quote-api.yaml#/paths/~1quote~1{id}'
+  /quotes/top10:
+    $ref: './quote-api.yaml#/paths/~1quotes~1top10'
+  /ping:
+    $ref: './ping-api.yaml#/paths/~1ping'
+  /secure/ping:
+    $ref: './ping-api.yaml#/paths/~1secure~1ping'
 components:
   schemas:
     Quote:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-          description: Identifier of the quote
-        quote:
-          type: string
-          description: Text content of the quote
-        song:
-          type: string
-          description: Name of the song the quote belongs to
-        album:
-          type: string
-          description: Album that contains the song
-        year:
-          type: integer
-          format: int32
-          description: Release year of the song
-        artist:
-          type: string
-          description: Artist attributed to the quote
-        posts:
-          type: integer
-          format: int32
-          description: Number of times the quote has been posted
-        hits:
-          type: integer
-          format: int32
-          description: Number of times the quote has been viewed
-        spotifyArtistId:
-          type: string
-          description: Spotify identifier of the artist
+      $ref: './components/schemas.yaml#/Quote'
     Artist:
-      type: object
-      required:
-        - id
-        - name
-        - genres
-        - popularity
-        - spotifyUrl
-        - topTracks
-      properties:
-        id:
-          type: string
-          description: Spotify identifier of the artist
-        name:
-          type: string
-          description: Name of the artist
-        genres:
-          type: array
-          description: Genres associated with the artist
-          items:
-            type: string
-        popularity:
-          type: integer
-          format: int32
-          description: Popularity score assigned by Spotify
-        imageUrl:
-          type: string
-          description: URL pointing to an image of the artist
-        spotifyUrl:
-          type: string
-          description: Spotify URL of the artist
-        topTracks:
-          type: array
-          description: Top Spotify tracks for the artist
-          items:
-            $ref: '#/components/schemas/ArtistTrack'
+      $ref: './components/schemas.yaml#/Artist'
     ArtistTrack:
-      type: object
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: string
-          description: Spotify identifier of the track
-        name:
-          type: string
-          description: Track name
-        previewUrl:
-          type: string
-          nullable: true
-          description: Preview URL for the track
+      $ref: './components/schemas.yaml#/ArtistTrack'
     ArtistQuoteCount:
-      type: object
-      required:
-        - id
-        - artist
-        - quotes
-      properties:
-        id:
-          type: string
-          description: Spotify identifier of the artist
-        artist:
-          type: string
-          description: Name of the artist
-        quotes:
-          type: integer
-          format: int64
-          description: Number of quotes stored for the artist
+      $ref: './components/schemas.yaml#/ArtistQuoteCount'


### PR DESCRIPTION
## Summary
- create dedicated OpenAPI definitions for the admin, artist, quote, and ping APIs and share reusable schemas
- update the aggregated song-quotes-service specification to reference the split API files and shared components

## Testing
- mvn -pl api clean package

------
https://chatgpt.com/codex/tasks/task_e_68d8de6ed8f88329a6c80b7178731944