### PR TITLE
Update k6 load test endpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,26 @@ with Maven:
 
 JaCoCo reports are written to `target/site/jacoco/index.html` and can be opened
 in a browser for local inspection.
+
+## Load testing
+
+The `load-testing/random-quote-load-test.js` script defines a [k6](https://k6.io)
+scenario that exercises the `GET /api/quote/random` endpoint exposed at
+`http://192.168.1.139:30015` and validates basic latency and error-rate
+thresholds that can be visualized in Grafana.
+
+Run the script by pointing it at a deployed instance of the service:
+
+```bash
+ENDPOINT_URL=https://song-quotes.example.com/api/quote/random \
+VUS=10 \
+DURATION=5m \
+SLEEP=0.5 \
+k6 run load-testing/random-quote-load-test.js
+```
+
+You can adjust the virtual users (`VUS`), test `DURATION`, per-iteration delay
+(`SLEEP`), or override the `ENDPOINT_URL` to target different environments. The
+script exposes custom metrics (`random_quote_request_rate` and
+`random_quote_request_duration`) that can be scraped by Prometheus and plotted
+in Grafana dashboards alongside built-in k6 metrics.

--- a/load-testing/random-quote-load-test.js
+++ b/load-testing/random-quote-load-test.js
@@ -1,0 +1,39 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+const ENDPOINT_URL = __ENV.ENDPOINT_URL || 'http://192.168.1.139:30015/api/quote/random';
+const REQUEST_RATE = new Rate('random_quote_request_rate');
+const REQUEST_DURATION = new Trend('random_quote_request_duration');
+
+export const options = {
+  vus: Number(__ENV.VUS || 5),
+  duration: __ENV.DURATION || '1m',
+  thresholds: {
+    http_req_failed: [
+      'rate<0.01',
+    ],
+    http_req_duration: [
+      'p(95)<500',
+    ],
+    random_quote_request_rate: [
+      'rate>0.99',
+    ],
+    random_quote_request_duration: [
+      'p(95)<500',
+    ],
+  },
+};
+
+export default function () {
+  const response = http.get(ENDPOINT_URL);
+
+  const isSuccessful = check(response, {
+    'status is 200 or 404': (res) => res.status === 200 || res.status === 404,
+  });
+
+  REQUEST_RATE.add(isSuccessful);
+  REQUEST_DURATION.add(response.timings.duration);
+
+  sleep(Number(__ENV.SLEEP || 1));
+}


### PR DESCRIPTION
## Summary
- update the k6 load test script to target the cluster's random quote endpoint by default
- refresh the README instructions to document the new ENDPOINT_URL override

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8f4f1eee48329bb6d961c7d794ed1