### PR TITLE
Add admin reset hits endpoint to application module

### DIFF
--- a/api/src/main/resources/openapi/admin-api.yaml
+++ b/api/src/main/resources/openapi/admin-api.yaml
@@ -114,6 +114,15 @@ paths:
             text/plain:
               schema:
                 type: string
+  /admin/quotes/reset-hits:
+    post:
+      tags:
+        - Admin
+      summary: Reset hit counters for all quotes
+      operationId: resetQuoteHits
+      responses:
+        '204':
+          description: Quote hits successfully reset
 components:
   schemas:
     Quote:

--- a/api/src/main/resources/openapi/song-quotes-service.yaml
+++ b/api/src/main/resources/openapi/song-quotes-service.yaml
@@ -19,6 +19,8 @@ paths:
     $ref: './admin-api.yaml#/paths/~1admin~1quote~1{id}'
   /admin/export:
     $ref: './admin-api.yaml#/paths/~1admin~1export'
+  /admin/quotes/reset-hits:
+    $ref: './admin-api.yaml#/paths/~1admin~1quotes~1reset-hits'
   /quotes:
     $ref: './quote-api.yaml#/paths/~1quotes'
   /quotes/count:

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -7,6 +7,7 @@ import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.application.service.AdminService;
 import com.xavelo.sqs.application.service.QuoteHelper;
 import com.xavelo.sqs.port.in.PatchQuoteUseCase;
+import com.xavelo.sqs.port.in.ResetQuoteHitsUseCase;
 import com.xavelo.sqs.port.in.StoreQuoteUseCase;
 import com.xavelo.sqs.port.in.UpdateQuoteUseCase;
 import jakarta.validation.Valid;
@@ -24,17 +25,20 @@ public class AdminController implements AdminApi {
     private final StoreQuoteUseCase storeQuoteUseCase;
     private final UpdateQuoteUseCase updateQuoteUseCase;
     private final PatchQuoteUseCase patchQuoteUseCase;
+    private final ResetQuoteHitsUseCase resetQuoteHitsUseCase;
     private final AdminQuoteMapper quoteMapper;
 
     public AdminController(AdminService adminService,
                            StoreQuoteUseCase storeQuoteUseCase,
                            UpdateQuoteUseCase updateQuoteUseCase,
                            PatchQuoteUseCase patchQuoteUseCase,
+                           ResetQuoteHitsUseCase resetQuoteHitsUseCase,
                            AdminQuoteMapper quoteMapper) {
         this.adminService = adminService;
         this.storeQuoteUseCase = storeQuoteUseCase;
         this.updateQuoteUseCase = updateQuoteUseCase;
         this.patchQuoteUseCase = patchQuoteUseCase;
+        this.resetQuoteHitsUseCase = resetQuoteHitsUseCase;
         this.quoteMapper = quoteMapper;
     }
 
@@ -86,6 +90,12 @@ public class AdminController implements AdminApi {
     public ResponseEntity<String> exportQuotes() {
         String sql = adminService.exportQuotesAsSql();
         return ResponseEntity.ok(sql);
+    }
+
+    @Override
+    public ResponseEntity<Void> resetQuoteHits() {
+        resetQuoteHitsUseCase.resetAllQuoteHits();
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort {
+public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, ResetQuoteHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort {
 
     private static final Logger logger = LogManager.getLogger(MysqlAdapter.class);
 
@@ -131,6 +131,11 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     @Override
     public void incrementHits(Long id) {
         quoteRepository.incrementHits(id);
+    }
+
+    @Override
+    public void resetAllQuoteHits() {
+        quoteRepository.resetAllHits();
     }
 
     @Override

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepository.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepository.java
@@ -27,6 +27,11 @@ public interface QuoteRepository extends JpaRepository<QuoteEntity, Long> {
     @Query("update QuoteEntity q set q.hits = q.hits + 1 where q.id = :id")
     void incrementHits(@Param("id") Long id);
 
+    @Transactional
+    @Modifying
+    @Query("update QuoteEntity q set q.hits = 0")
+    void resetAllHits();
+
     /**
      * Retrieve the number of quotes for each artist.
      */

--- a/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
@@ -1,27 +1,34 @@
 package com.xavelo.sqs.application.service;
 
 import com.xavelo.sqs.application.domain.Quote;
-import com.xavelo.sqs.port.in.ExportQuotesUseCase;
 import com.xavelo.sqs.port.in.DeleteQuoteUseCase;
+import com.xavelo.sqs.port.in.ExportQuotesUseCase;
+import com.xavelo.sqs.port.in.ResetQuoteHitsUseCase;
 import com.xavelo.sqs.port.in.UpdateQuoteUseCase;
 import com.xavelo.sqs.port.out.DeleteQuotePort;
 import com.xavelo.sqs.port.out.LoadQuotePort;
+import com.xavelo.sqs.port.out.ResetQuoteHitsPort;
 import com.xavelo.sqs.port.out.UpdateQuotePort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, UpdateQuoteUseCase {
+public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, UpdateQuoteUseCase, ResetQuoteHitsUseCase {
 
     private final LoadQuotePort loadQuotePort;
     private final DeleteQuotePort deleteQuotePort;
     private final UpdateQuotePort updateQuotePort;
+    private final ResetQuoteHitsPort resetQuoteHitsPort;
 
-    public AdminService(LoadQuotePort loadQuotePort, DeleteQuotePort deleteQuotePort, UpdateQuotePort updateQuotePort) {
+    public AdminService(LoadQuotePort loadQuotePort,
+                        DeleteQuotePort deleteQuotePort,
+                        UpdateQuotePort updateQuotePort,
+                        ResetQuoteHitsPort resetQuoteHitsPort) {
         this.loadQuotePort = loadQuotePort;
         this.deleteQuotePort = deleteQuotePort;
         this.updateQuotePort = updateQuotePort;
+        this.resetQuoteHitsPort = resetQuoteHitsPort;
     }
 
     @Override
@@ -52,5 +59,10 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
     @Override
     public void updateQuote(Quote quote) {
         updateQuotePort.updateQuote(quote);
+    }
+
+    @Override
+    public void resetAllQuoteHits() {
+        resetQuoteHitsPort.resetAllQuoteHits();
     }
 }

--- a/application/src/main/java/com/xavelo/sqs/port/in/ResetQuoteHitsUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/ResetQuoteHitsUseCase.java
@@ -1,0 +1,5 @@
+package com.xavelo.sqs.port.in;
+
+public interface ResetQuoteHitsUseCase {
+    void resetAllQuoteHits();
+}

--- a/application/src/main/java/com/xavelo/sqs/port/out/ResetQuoteHitsPort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/ResetQuoteHitsPort.java
@@ -1,0 +1,5 @@
+package com.xavelo.sqs.port.out;
+
+public interface ResetQuoteHitsPort {
+    void resetAllQuoteHits();
+}

--- a/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -4,6 +4,7 @@ import com.xavelo.sqs.application.service.AdminService;
 import com.xavelo.sqs.port.in.StoreQuoteUseCase;
 import com.xavelo.sqs.port.in.UpdateQuoteUseCase;
 import com.xavelo.sqs.port.in.PatchQuoteUseCase;
+import com.xavelo.sqs.port.in.ResetQuoteHitsUseCase;
 import com.xavelo.sqs.application.domain.Quote;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,15 +18,18 @@ public class AdminController {
     private final StoreQuoteUseCase storeQuoteUseCase;
     private final UpdateQuoteUseCase updateQuoteUseCase;
     private final PatchQuoteUseCase patchQuoteUseCase;
+    private final ResetQuoteHitsUseCase resetQuoteHitsUseCase;
 
     public AdminController(AdminService adminService,
                            StoreQuoteUseCase storeQuoteUseCase,
                            UpdateQuoteUseCase updateQuoteUseCase,
-                           PatchQuoteUseCase patchQuoteUseCase) {
+                           PatchQuoteUseCase patchQuoteUseCase,
+                           ResetQuoteHitsUseCase resetQuoteHitsUseCase) {
         this.adminService = adminService;
         this.storeQuoteUseCase = storeQuoteUseCase;
         this.updateQuoteUseCase = updateQuoteUseCase;
         this.patchQuoteUseCase = patchQuoteUseCase;
+        this.resetQuoteHitsUseCase = resetQuoteHitsUseCase;
     }
 
     @PostMapping("/quote")
@@ -72,6 +76,12 @@ public class AdminController {
     public ResponseEntity<String> exportQuotes() {
         String sql = adminService.exportQuotesAsSql();
         return ResponseEntity.ok(sql);
+    }
+
+    @PostMapping("/quotes/reset-hits")
+    public ResponseEntity<Void> resetQuoteHits() {
+        resetQuoteHitsUseCase.resetAllQuoteHits();
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
+++ b/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort {
+public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort, ResetQuoteHitsPort {
 
     private static final Logger logger = LogManager.getLogger(MysqlAdapter.class);
 
@@ -131,6 +131,11 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     @Override
     public void incrementHits(Long id) {
         quoteRepository.incrementHits(id);
+    }
+
+    @Override
+    public void resetAllQuoteHits() {
+        quoteRepository.resetAllHits();
     }
 
     @Override

--- a/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepository.java
+++ b/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepository.java
@@ -27,6 +27,11 @@ public interface QuoteRepository extends JpaRepository<QuoteEntity, Long> {
     @Query("update QuoteEntity q set q.hits = q.hits + 1 where q.id = :id")
     void incrementHits(@Param("id") Long id);
 
+    @Transactional
+    @Modifying
+    @Query("update QuoteEntity q set q.hits = 0")
+    void resetAllHits();
+
     /**
      * Retrieve the number of quotes for each artist.
      */

--- a/src/main/java/com/xavelo/sqs/application/service/AdminService.java
+++ b/src/main/java/com/xavelo/sqs/application/service/AdminService.java
@@ -3,25 +3,30 @@ package com.xavelo.sqs.application.service;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.in.ExportQuotesUseCase;
 import com.xavelo.sqs.port.in.DeleteQuoteUseCase;
+import com.xavelo.sqs.port.in.ResetQuoteHitsUseCase;
 import com.xavelo.sqs.port.in.UpdateQuoteUseCase;
 import com.xavelo.sqs.port.out.DeleteQuotePort;
 import com.xavelo.sqs.port.out.LoadQuotePort;
 import com.xavelo.sqs.port.out.UpdateQuotePort;
+import com.xavelo.sqs.port.out.ResetQuoteHitsPort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, UpdateQuoteUseCase {
+public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, UpdateQuoteUseCase, ResetQuoteHitsUseCase {
 
     private final LoadQuotePort loadQuotePort;
     private final DeleteQuotePort deleteQuotePort;
     private final UpdateQuotePort updateQuotePort;
+    private final ResetQuoteHitsPort resetQuoteHitsPort;
 
-    public AdminService(LoadQuotePort loadQuotePort, DeleteQuotePort deleteQuotePort, UpdateQuotePort updateQuotePort) {
+    public AdminService(LoadQuotePort loadQuotePort, DeleteQuotePort deleteQuotePort, UpdateQuotePort updateQuotePort,
+                        ResetQuoteHitsPort resetQuoteHitsPort) {
         this.loadQuotePort = loadQuotePort;
         this.deleteQuotePort = deleteQuotePort;
         this.updateQuotePort = updateQuotePort;
+        this.resetQuoteHitsPort = resetQuoteHitsPort;
     }
 
     @Override
@@ -52,5 +57,10 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
     @Override
     public void updateQuote(Quote quote) {
         updateQuotePort.updateQuote(quote);
+    }
+
+    @Override
+    public void resetAllQuoteHits() {
+        resetQuoteHitsPort.resetAllQuoteHits();
     }
 }

--- a/src/main/java/com/xavelo/sqs/port/in/ResetQuoteHitsUseCase.java
+++ b/src/main/java/com/xavelo/sqs/port/in/ResetQuoteHitsUseCase.java
@@ -1,0 +1,5 @@
+package com.xavelo.sqs.port.in;
+
+public interface ResetQuoteHitsUseCase {
+    void resetAllQuoteHits();
+}

--- a/src/main/java/com/xavelo/sqs/port/out/ResetQuoteHitsPort.java
+++ b/src/main/java/com/xavelo/sqs/port/out/ResetQuoteHitsPort.java
@@ -1,0 +1,5 @@
+package com.xavelo.sqs.port.out;
+
+public interface ResetQuoteHitsPort {
+    void resetAllQuoteHits();
+}


### PR DESCRIPTION
## Summary
- expose the POST /admin/quotes/reset-hits operation in the OpenAPI definition and admin controller
- implement the reset hits use case in the application service backed by the MySQL adapter
- add repository and port contracts so the adapter can zero out hit counts for every quote

## Testing
- `./mvnw -q test` *(fails: Network is unreachable while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ff91232483298dfea063b8d88386