### PR TITLE
Add admin endpoint to reset quote hits

### DIFF
--- a/api/src/main/resources/openapi/admin-api.yaml
+++ b/api/src/main/resources/openapi/admin-api.yaml
@@ -101,6 +101,15 @@ paths:
           description: Quote successfully updated
         '400':
           description: Quote contains restricted fields
+  /admin/quotes/reset-hits:
+    post:
+      tags:
+        - Admin
+      summary: Reset hits for all quotes
+      operationId: resetQuoteHits
+      responses:
+        '204':
+          description: Hits successfully reset
   /admin/export:
     get:
       tags:

--- a/api/src/main/resources/openapi/song-quotes-service.yaml
+++ b/api/src/main/resources/openapi/song-quotes-service.yaml
@@ -15,6 +15,8 @@ paths:
     $ref: './admin-api.yaml#/paths/~1admin~1quote'
   /admin/quotes:
     $ref: './admin-api.yaml#/paths/~1admin~1quotes'
+  /admin/quotes/reset-hits:
+    $ref: './admin-api.yaml#/paths/~1admin~1quotes~1reset-hits'
   /admin/quote/{id}:
     $ref: './admin-api.yaml#/paths/~1admin~1quote~1{id}'
   /admin/export:

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -7,6 +7,7 @@ import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.application.service.AdminService;
 import com.xavelo.sqs.application.service.QuoteHelper;
 import com.xavelo.sqs.port.in.PatchQuoteUseCase;
+import com.xavelo.sqs.port.in.ResetQuoteHitsUseCase;
 import com.xavelo.sqs.port.in.StoreQuoteUseCase;
 import com.xavelo.sqs.port.in.UpdateQuoteUseCase;
 import jakarta.validation.Valid;
@@ -24,17 +25,20 @@ public class AdminController implements AdminApi {
     private final StoreQuoteUseCase storeQuoteUseCase;
     private final UpdateQuoteUseCase updateQuoteUseCase;
     private final PatchQuoteUseCase patchQuoteUseCase;
+    private final ResetQuoteHitsUseCase resetQuoteHitsUseCase;
     private final AdminQuoteMapper quoteMapper;
 
     public AdminController(AdminService adminService,
                            StoreQuoteUseCase storeQuoteUseCase,
                            UpdateQuoteUseCase updateQuoteUseCase,
                            PatchQuoteUseCase patchQuoteUseCase,
+                           ResetQuoteHitsUseCase resetQuoteHitsUseCase,
                            AdminQuoteMapper quoteMapper) {
         this.adminService = adminService;
         this.storeQuoteUseCase = storeQuoteUseCase;
         this.updateQuoteUseCase = updateQuoteUseCase;
         this.patchQuoteUseCase = patchQuoteUseCase;
+        this.resetQuoteHitsUseCase = resetQuoteHitsUseCase;
         this.quoteMapper = quoteMapper;
     }
 
@@ -86,6 +90,12 @@ public class AdminController implements AdminApi {
     public ResponseEntity<String> exportQuotes() {
         String sql = adminService.exportQuotesAsSql();
         return ResponseEntity.ok(sql);
+    }
+
+    @Override
+    public ResponseEntity<Void> resetQuoteHits() {
+        resetQuoteHitsUseCase.resetQuoteHits();
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort {
+public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort, ResetQuoteHitsPort {
 
     private static final Logger logger = LogManager.getLogger(MysqlAdapter.class);
 
@@ -131,6 +131,11 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     @Override
     public void incrementHits(Long id) {
         quoteRepository.incrementHits(id);
+    }
+
+    @Override
+    public void resetQuoteHits() {
+        quoteRepository.resetHits();
     }
 
     @Override

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepository.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepository.java
@@ -27,6 +27,11 @@ public interface QuoteRepository extends JpaRepository<QuoteEntity, Long> {
     @Query("update QuoteEntity q set q.hits = q.hits + 1 where q.id = :id")
     void incrementHits(@Param("id") Long id);
 
+    @Transactional
+    @Modifying
+    @Query("update QuoteEntity q set q.hits = 0")
+    void resetHits();
+
     /**
      * Retrieve the number of quotes for each artist.
      */

--- a/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
@@ -3,25 +3,32 @@ package com.xavelo.sqs.application.service;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.in.ExportQuotesUseCase;
 import com.xavelo.sqs.port.in.DeleteQuoteUseCase;
+import com.xavelo.sqs.port.in.ResetQuoteHitsUseCase;
 import com.xavelo.sqs.port.in.UpdateQuoteUseCase;
 import com.xavelo.sqs.port.out.DeleteQuotePort;
 import com.xavelo.sqs.port.out.LoadQuotePort;
+import com.xavelo.sqs.port.out.ResetQuoteHitsPort;
 import com.xavelo.sqs.port.out.UpdateQuotePort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, UpdateQuoteUseCase {
+public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, UpdateQuoteUseCase, ResetQuoteHitsUseCase {
 
     private final LoadQuotePort loadQuotePort;
     private final DeleteQuotePort deleteQuotePort;
     private final UpdateQuotePort updateQuotePort;
+    private final ResetQuoteHitsPort resetQuoteHitsPort;
 
-    public AdminService(LoadQuotePort loadQuotePort, DeleteQuotePort deleteQuotePort, UpdateQuotePort updateQuotePort) {
+    public AdminService(LoadQuotePort loadQuotePort,
+                        DeleteQuotePort deleteQuotePort,
+                        UpdateQuotePort updateQuotePort,
+                        ResetQuoteHitsPort resetQuoteHitsPort) {
         this.loadQuotePort = loadQuotePort;
         this.deleteQuotePort = deleteQuotePort;
         this.updateQuotePort = updateQuotePort;
+        this.resetQuoteHitsPort = resetQuoteHitsPort;
     }
 
     @Override
@@ -52,5 +59,10 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
     @Override
     public void updateQuote(Quote quote) {
         updateQuotePort.updateQuote(quote);
+    }
+
+    @Override
+    public void resetQuoteHits() {
+        resetQuoteHitsPort.resetQuoteHits();
     }
 }

--- a/application/src/main/java/com/xavelo/sqs/port/in/ResetQuoteHitsUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/ResetQuoteHitsUseCase.java
@@ -1,0 +1,6 @@
+package com.xavelo.sqs.port.in;
+
+public interface ResetQuoteHitsUseCase {
+
+    void resetQuoteHits();
+}

--- a/application/src/main/java/com/xavelo/sqs/port/out/ResetQuoteHitsPort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/ResetQuoteHitsPort.java
@@ -1,0 +1,6 @@
+package com.xavelo.sqs.port.out;
+
+public interface ResetQuoteHitsPort {
+
+    void resetQuoteHits();
+}


### PR DESCRIPTION
## Summary
- add OpenAPI definitions for a reset-hits admin endpoint
- implement ports, service logic, and repository update to zero out quote hits
- expose the new admin controller endpoint that triggers the reset

## Testing
- ./mvnw -pl application test *(fails: network is unreachable when downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d915d04404832996d7e748c3f4f43a