### PR TITLE
Add admin reset posts endpoint

### DIFF
--- a/api/src/main/resources/openapi/admin-api.yaml
+++ b/api/src/main/resources/openapi/admin-api.yaml
@@ -110,6 +110,15 @@ paths:
       responses:
         '204':
           description: Hits successfully reset
+  /admin/quotes/reset-posts:
+    post:
+      tags:
+        - Admin
+      summary: Reset posts for all quotes
+      operationId: resetQuotePosts
+      responses:
+        '204':
+          description: Posts successfully reset
   /admin/export:
     get:
       tags:

--- a/api/src/main/resources/openapi/song-quotes-service.yaml
+++ b/api/src/main/resources/openapi/song-quotes-service.yaml
@@ -17,6 +17,8 @@ paths:
     $ref: './admin-api.yaml#/paths/~1admin~1quotes'
   /admin/quotes/reset-hits:
     $ref: './admin-api.yaml#/paths/~1admin~1quotes~1reset-hits'
+  /admin/quotes/reset-posts:
+    $ref: './admin-api.yaml#/paths/~1admin~1quotes~1reset-posts'
   /admin/quote/{id}:
     $ref: './admin-api.yaml#/paths/~1admin~1quote~1{id}'
   /admin/export:

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -8,6 +8,7 @@ import com.xavelo.sqs.application.service.AdminService;
 import com.xavelo.sqs.application.service.QuoteHelper;
 import com.xavelo.sqs.port.in.PatchQuoteUseCase;
 import com.xavelo.sqs.port.in.ResetQuoteHitsUseCase;
+import com.xavelo.sqs.port.in.ResetQuotePostsUseCase;
 import com.xavelo.sqs.port.in.StoreQuoteUseCase;
 import com.xavelo.sqs.port.in.UpdateQuoteUseCase;
 import jakarta.validation.Valid;
@@ -26,6 +27,7 @@ public class AdminController implements AdminApi {
     private final UpdateQuoteUseCase updateQuoteUseCase;
     private final PatchQuoteUseCase patchQuoteUseCase;
     private final ResetQuoteHitsUseCase resetQuoteHitsUseCase;
+    private final ResetQuotePostsUseCase resetQuotePostsUseCase;
     private final AdminQuoteMapper quoteMapper;
 
     public AdminController(AdminService adminService,
@@ -33,12 +35,14 @@ public class AdminController implements AdminApi {
                            UpdateQuoteUseCase updateQuoteUseCase,
                            PatchQuoteUseCase patchQuoteUseCase,
                            ResetQuoteHitsUseCase resetQuoteHitsUseCase,
+                           ResetQuotePostsUseCase resetQuotePostsUseCase,
                            AdminQuoteMapper quoteMapper) {
         this.adminService = adminService;
         this.storeQuoteUseCase = storeQuoteUseCase;
         this.updateQuoteUseCase = updateQuoteUseCase;
         this.patchQuoteUseCase = patchQuoteUseCase;
         this.resetQuoteHitsUseCase = resetQuoteHitsUseCase;
+        this.resetQuotePostsUseCase = resetQuotePostsUseCase;
         this.quoteMapper = quoteMapper;
     }
 
@@ -95,6 +99,12 @@ public class AdminController implements AdminApi {
     @Override
     public ResponseEntity<Void> resetQuoteHits() {
         resetQuoteHitsUseCase.resetQuoteHits();
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> resetQuotePosts() {
+        resetQuotePostsUseCase.resetQuotePosts();
         return ResponseEntity.noContent().build();
     }
 

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort, ResetQuoteHitsPort {
+public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort, ResetQuoteHitsPort, ResetQuotePostsPort {
 
     private static final Logger logger = LogManager.getLogger(MysqlAdapter.class);
 
@@ -136,6 +136,11 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     @Override
     public void resetQuoteHits() {
         quoteRepository.resetHits();
+    }
+
+    @Override
+    public void resetQuotePosts() {
+        quoteRepository.resetPosts();
     }
 
     @Override

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepository.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepository.java
@@ -32,6 +32,11 @@ public interface QuoteRepository extends JpaRepository<QuoteEntity, Long> {
     @Query("update QuoteEntity q set q.hits = 0")
     void resetHits();
 
+    @Transactional
+    @Modifying
+    @Query("update QuoteEntity q set q.posts = 0")
+    void resetPosts();
+
     /**
      * Retrieve the number of quotes for each artist.
      */

--- a/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
@@ -4,31 +4,36 @@ import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.in.ExportQuotesUseCase;
 import com.xavelo.sqs.port.in.DeleteQuoteUseCase;
 import com.xavelo.sqs.port.in.ResetQuoteHitsUseCase;
+import com.xavelo.sqs.port.in.ResetQuotePostsUseCase;
 import com.xavelo.sqs.port.in.UpdateQuoteUseCase;
 import com.xavelo.sqs.port.out.DeleteQuotePort;
 import com.xavelo.sqs.port.out.LoadQuotePort;
 import com.xavelo.sqs.port.out.ResetQuoteHitsPort;
+import com.xavelo.sqs.port.out.ResetQuotePostsPort;
 import com.xavelo.sqs.port.out.UpdateQuotePort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, UpdateQuoteUseCase, ResetQuoteHitsUseCase {
+public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, UpdateQuoteUseCase, ResetQuoteHitsUseCase, ResetQuotePostsUseCase {
 
     private final LoadQuotePort loadQuotePort;
     private final DeleteQuotePort deleteQuotePort;
     private final UpdateQuotePort updateQuotePort;
     private final ResetQuoteHitsPort resetQuoteHitsPort;
+    private final ResetQuotePostsPort resetQuotePostsPort;
 
     public AdminService(LoadQuotePort loadQuotePort,
                         DeleteQuotePort deleteQuotePort,
                         UpdateQuotePort updateQuotePort,
-                        ResetQuoteHitsPort resetQuoteHitsPort) {
+                        ResetQuoteHitsPort resetQuoteHitsPort,
+                        ResetQuotePostsPort resetQuotePostsPort) {
         this.loadQuotePort = loadQuotePort;
         this.deleteQuotePort = deleteQuotePort;
         this.updateQuotePort = updateQuotePort;
         this.resetQuoteHitsPort = resetQuoteHitsPort;
+        this.resetQuotePostsPort = resetQuotePostsPort;
     }
 
     @Override
@@ -64,5 +69,10 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
     @Override
     public void resetQuoteHits() {
         resetQuoteHitsPort.resetQuoteHits();
+    }
+
+    @Override
+    public void resetQuotePosts() {
+        resetQuotePostsPort.resetQuotePosts();
     }
 }

--- a/application/src/main/java/com/xavelo/sqs/port/in/ResetQuotePostsUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/ResetQuotePostsUseCase.java
@@ -1,0 +1,6 @@
+package com.xavelo.sqs.port.in;
+
+public interface ResetQuotePostsUseCase {
+
+    void resetQuotePosts();
+}

--- a/application/src/main/java/com/xavelo/sqs/port/out/ResetQuotePostsPort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/ResetQuotePostsPort.java
@@ -1,0 +1,6 @@
+package com.xavelo.sqs.port.out;
+
+public interface ResetQuotePostsPort {
+
+    void resetQuotePosts();
+}


### PR DESCRIPTION
## Summary
- extend the admin OpenAPI specification and controller with a reset-posts endpoint mirroring the existing hits reset
- add application ports and service logic to support resetting post counters via the MySQL adapter

## Testing
- ./mvnw -pl application test *(fails: network unreachable while downloading maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d953a5032883298f133db6435b88f5