### PR TITLE
Add quote event outbox and relay worker

### DIFF
--- a/application/src/main/java/com/xavelo/sqs/SongQuotesServiceApplication.java
+++ b/application/src/main/java/com/xavelo/sqs/SongQuotesServiceApplication.java
@@ -3,9 +3,11 @@ package com.xavelo.sqs;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 public class SongQuotesServiceApplication {
 
 	public static void main(String[] args) {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventEntity.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventEntity.java
@@ -1,0 +1,141 @@
+package com.xavelo.sqs.adapter.out.mysql.outbox;
+
+import com.xavelo.sqs.application.domain.QuoteEventType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quote_events")
+public class QuoteEventEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private QuoteEventType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private QuoteEventStatus status;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Column(nullable = false)
+    private Integer attempts;
+
+    @Column(name = "last_error", columnDefinition = "TEXT")
+    private String lastError;
+
+    @Column(name = "available_at", nullable = false)
+    private LocalDateTime availableAt;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public QuoteEventEntity() {
+    }
+
+    public QuoteEventEntity(QuoteEventType type, QuoteEventStatus status, String payload) {
+        this.type = type;
+        this.status = status;
+        this.payload = payload;
+        this.attempts = 0;
+    }
+
+    @PrePersist
+    void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        if (this.availableAt == null) {
+            this.availableAt = now;
+        }
+        if (this.attempts == null) {
+            this.attempts = 0;
+        }
+        if (this.status == null) {
+            this.status = QuoteEventStatus.PENDING;
+        }
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public QuoteEventType getType() {
+        return type;
+    }
+
+    public void setType(QuoteEventType type) {
+        this.type = type;
+    }
+
+    public QuoteEventStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(QuoteEventStatus status) {
+        this.status = status;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public Integer getAttempts() {
+        return attempts;
+    }
+
+    public void setAttempts(Integer attempts) {
+        this.attempts = attempts;
+    }
+
+    public String getLastError() {
+        return lastError;
+    }
+
+    public void setLastError(String lastError) {
+        this.lastError = lastError;
+    }
+
+    public LocalDateTime getAvailableAt() {
+        return availableAt;
+    }
+
+    public void setAvailableAt(LocalDateTime availableAt) {
+        this.availableAt = availableAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxAdapter.java
@@ -1,0 +1,97 @@
+package com.xavelo.sqs.adapter.out.mysql.outbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xavelo.sqs.application.domain.Quote;
+import com.xavelo.sqs.application.domain.QuoteEvent;
+import com.xavelo.sqs.application.domain.QuoteEventType;
+import com.xavelo.sqs.port.out.QuoteEventOutboxPort;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+public class QuoteEventOutboxAdapter implements QuoteEventOutboxPort {
+
+    private final QuoteEventOutboxRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public QuoteEventOutboxAdapter(QuoteEventOutboxRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @Transactional
+    public void recordQuoteCreatedEvent(Quote quote) {
+        persistEvent(quote, QuoteEventType.CREATED);
+    }
+
+    @Override
+    @Transactional
+    public void recordQuoteHitEvent(Quote quote) {
+        persistEvent(quote, QuoteEventType.HIT);
+    }
+
+    private void persistEvent(Quote quote, QuoteEventType type) {
+        try {
+            String payload = objectMapper.writeValueAsString(quote);
+            QuoteEventEntity entity = new QuoteEventEntity(type, QuoteEventStatus.PENDING, payload);
+            repository.save(entity);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize quote for outbox", e);
+        }
+    }
+
+    @Override
+    @Transactional
+    public List<QuoteEvent> fetchPendingEvents(int batchSize) {
+        List<QuoteEventEntity> entities = repository.findPendingEvents(
+                QuoteEventStatus.PENDING,
+                LocalDateTime.now(),
+                PageRequest.of(0, batchSize)
+        );
+
+        entities.forEach(entity -> {
+            entity.setStatus(QuoteEventStatus.PROCESSING);
+            entity.setAttempts(entity.getAttempts() + 1);
+        });
+
+        return entities.stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    private QuoteEvent toDomain(QuoteEventEntity entity) {
+        try {
+            Quote quote = objectMapper.readValue(entity.getPayload(), Quote.class);
+            return new QuoteEvent(entity.getId(), entity.getType(), quote, entity.getAttempts());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to deserialize quote event payload", e);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void markEventPublished(Long id) {
+        repository.findById(id).ifPresent(entity -> {
+            entity.setStatus(QuoteEventStatus.PUBLISHED);
+            entity.setLastError(null);
+        });
+    }
+
+    @Override
+    @Transactional
+    public void markEventFailed(Long id, String errorMessage, Duration retryDelay) {
+        repository.findById(id).ifPresent(entity -> {
+            entity.setStatus(QuoteEventStatus.PENDING);
+            entity.setLastError(errorMessage);
+            LocalDateTime nextAttempt = LocalDateTime.now().plus(retryDelay);
+            entity.setAvailableAt(nextAttempt);
+        });
+    }
+}

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxRepository.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxRepository.java
@@ -1,0 +1,17 @@
+package com.xavelo.sqs.adapter.out.mysql.outbox;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface QuoteEventOutboxRepository extends JpaRepository<QuoteEventEntity, Long> {
+
+    @Query("SELECT qe FROM QuoteEventEntity qe WHERE qe.status = :status AND qe.availableAt <= :availableAt ORDER BY qe.createdAt ASC")
+    List<QuoteEventEntity> findPendingEvents(@Param("status") QuoteEventStatus status,
+                                             @Param("availableAt") LocalDateTime availableAt,
+                                             Pageable pageable);
+}

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventStatus.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventStatus.java
@@ -1,0 +1,7 @@
+package com.xavelo.sqs.adapter.out.mysql.outbox;
+
+public enum QuoteEventStatus {
+    PENDING,
+    PROCESSING,
+    PUBLISHED
+}

--- a/application/src/main/java/com/xavelo/sqs/application/domain/QuoteEvent.java
+++ b/application/src/main/java/com/xavelo/sqs/application/domain/QuoteEvent.java
@@ -1,0 +1,9 @@
+package com.xavelo.sqs.application.domain;
+
+public record QuoteEvent(
+        Long id,
+        QuoteEventType type,
+        Quote quote,
+        int attempts
+) {
+}

--- a/application/src/main/java/com/xavelo/sqs/application/domain/QuoteEventType.java
+++ b/application/src/main/java/com/xavelo/sqs/application/domain/QuoteEventType.java
@@ -1,0 +1,6 @@
+package com.xavelo.sqs.application.domain;
+
+public enum QuoteEventType {
+    CREATED,
+    HIT
+}

--- a/application/src/main/java/com/xavelo/sqs/application/service/QuoteEventRelayWorker.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/QuoteEventRelayWorker.java
@@ -1,0 +1,64 @@
+package com.xavelo.sqs.application.service;
+
+import com.xavelo.sqs.application.domain.QuoteEvent;
+import com.xavelo.sqs.application.domain.QuoteEventType;
+import com.xavelo.sqs.port.out.PublishQuoteCreatedPort;
+import com.xavelo.sqs.port.out.PublishQuoteHitPort;
+import com.xavelo.sqs.port.out.QuoteEventOutboxPort;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+
+@Component
+public class QuoteEventRelayWorker {
+
+    private static final Logger logger = LogManager.getLogger(QuoteEventRelayWorker.class);
+
+    private final QuoteEventOutboxPort quoteEventOutboxPort;
+    private final PublishQuoteCreatedPort publishQuoteCreatedPort;
+    private final PublishQuoteHitPort publishQuoteHitPort;
+    private final int batchSize;
+    private final Duration retryDelay;
+
+    public QuoteEventRelayWorker(
+            QuoteEventOutboxPort quoteEventOutboxPort,
+            PublishQuoteCreatedPort publishQuoteCreatedPort,
+            PublishQuoteHitPort publishQuoteHitPort,
+            @Value("${quote-events.outbox.worker.batch-size:25}") int batchSize,
+            @Value("${quote-events.outbox.worker.retry-delay:PT30S}") Duration retryDelay) {
+        this.quoteEventOutboxPort = quoteEventOutboxPort;
+        this.publishQuoteCreatedPort = publishQuoteCreatedPort;
+        this.publishQuoteHitPort = publishQuoteHitPort;
+        this.batchSize = batchSize;
+        this.retryDelay = retryDelay;
+    }
+
+    @Scheduled(fixedDelayString = "${quote-events.outbox.worker.delay:5000}")
+    public void relayOutbox() {
+        List<QuoteEvent> events = quoteEventOutboxPort.fetchPendingEvents(batchSize);
+        for (QuoteEvent event : events) {
+            try {
+                publishEvent(event);
+                quoteEventOutboxPort.markEventPublished(event.id());
+            } catch (Exception ex) {
+                logger.error("Failed to publish quote event {}: {}", event.id(), ex.getMessage(), ex);
+                quoteEventOutboxPort.markEventFailed(event.id(), ex.getMessage(), retryDelay);
+            }
+        }
+    }
+
+    private void publishEvent(QuoteEvent event) {
+        if (event.type() == QuoteEventType.CREATED) {
+            publishQuoteCreatedPort.publishQuoteCreated(event.quote());
+        } else if (event.type() == QuoteEventType.HIT) {
+            publishQuoteHitPort.publishQuoteHit(event.quote());
+        } else {
+            logger.warn("Unsupported quote event type {} for event {}", event.type(), event.id());
+        }
+    }
+}

--- a/application/src/main/java/com/xavelo/sqs/port/out/QuoteEventOutboxPort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/QuoteEventOutboxPort.java
@@ -1,0 +1,19 @@
+package com.xavelo.sqs.port.out;
+
+import com.xavelo.sqs.application.domain.Quote;
+import com.xavelo.sqs.application.domain.QuoteEvent;
+
+import java.time.Duration;
+import java.util.List;
+
+public interface QuoteEventOutboxPort {
+    void recordQuoteCreatedEvent(Quote quote);
+
+    void recordQuoteHitEvent(Quote quote);
+
+    List<QuoteEvent> fetchPendingEvents(int batchSize);
+
+    void markEventPublished(Long id);
+
+    void markEventFailed(Long id, String errorMessage, Duration retryDelay);
+}

--- a/application/src/main/resources/db/migration/V3__create_quote_events_table.sql
+++ b/application/src/main/resources/db/migration/V3__create_quote_events_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE quote_events (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    type VARCHAR(32) NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    payload TEXT NOT NULL,
+    attempts INT NOT NULL DEFAULT 0,
+    last_error TEXT NULL,
+    available_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
+);
+
+CREATE INDEX idx_quote_events_status_available_at ON quote_events(status, available_at);

--- a/application/src/test/java/com/xavelo/sqs/application/service/QuoteEventRelayWorkerTest.java
+++ b/application/src/test/java/com/xavelo/sqs/application/service/QuoteEventRelayWorkerTest.java
@@ -1,0 +1,89 @@
+package com.xavelo.sqs.application.service;
+
+import com.xavelo.sqs.application.domain.Quote;
+import com.xavelo.sqs.application.domain.QuoteEvent;
+import com.xavelo.sqs.application.domain.QuoteEventType;
+import com.xavelo.sqs.port.out.PublishQuoteCreatedPort;
+import com.xavelo.sqs.port.out.PublishQuoteHitPort;
+import com.xavelo.sqs.port.out.QuoteEventOutboxPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class QuoteEventRelayWorkerTest {
+
+    @Mock
+    private QuoteEventOutboxPort quoteEventOutboxPort;
+
+    @Mock
+    private PublishQuoteCreatedPort publishQuoteCreatedPort;
+
+    @Mock
+    private PublishQuoteHitPort publishQuoteHitPort;
+
+    private QuoteEventRelayWorker worker;
+
+    @BeforeEach
+    void setUp() {
+        worker = new QuoteEventRelayWorker(quoteEventOutboxPort, publishQuoteCreatedPort, publishQuoteHitPort, 10, Duration.ofSeconds(30));
+    }
+
+    @Test
+    void relayOutbox_publishesCreatedEvent() {
+        Quote quote = new Quote(1L, "quote", "song", "album", 1990, "artist", 0, 0, null);
+        QuoteEvent event = new QuoteEvent(1L, QuoteEventType.CREATED, quote, 1);
+        when(quoteEventOutboxPort.fetchPendingEvents(10)).thenReturn(List.of(event));
+
+        worker.relayOutbox();
+
+        verify(publishQuoteCreatedPort).publishQuoteCreated(quote);
+        verify(quoteEventOutboxPort).markEventPublished(1L);
+    }
+
+    @Test
+    void relayOutbox_handlesPublishFailure() {
+        Quote quote = new Quote(1L, "quote", "song", "album", 1990, "artist", 0, 0, null);
+        QuoteEvent event = new QuoteEvent(1L, QuoteEventType.CREATED, quote, 1);
+        when(quoteEventOutboxPort.fetchPendingEvents(10)).thenReturn(List.of(event));
+        doThrow(new RuntimeException("boom")).when(publishQuoteCreatedPort).publishQuoteCreated(quote);
+
+        worker.relayOutbox();
+
+        verify(quoteEventOutboxPort).markEventFailed(eq(1L), eq("boom"), eq(Duration.ofSeconds(30)));
+    }
+
+    @Test
+    void relayOutbox_publishesHitEvent() {
+        Quote quote = new Quote(1L, "quote", "song", "album", 1990, "artist", 0, 1, null);
+        QuoteEvent event = new QuoteEvent(2L, QuoteEventType.HIT, quote, 1);
+        when(quoteEventOutboxPort.fetchPendingEvents(10)).thenReturn(List.of(event));
+
+        worker.relayOutbox();
+
+        verify(publishQuoteHitPort).publishQuoteHit(quote);
+        verify(quoteEventOutboxPort).markEventPublished(2L);
+    }
+
+    @Test
+    void relayOutbox_noEventsDoesNothing() {
+        when(quoteEventOutboxPort.fetchPendingEvents(10)).thenReturn(List.of());
+
+        worker.relayOutbox();
+
+        verify(quoteEventOutboxPort, times(1)).fetchPendingEvents(10);
+        verify(publishQuoteCreatedPort, times(0)).publishQuoteCreated(org.mockito.ArgumentMatchers.any());
+        verify(publishQuoteHitPort, times(0)).publishQuoteHit(org.mockito.ArgumentMatchers.any());
+    }
+}


### PR DESCRIPTION
## Summary
- add a MySQL-backed quote event outbox with domain types, repository, and migration to persist publication intents atomically
- enqueue quote created and hit events from QuoteService and introduce a scheduled relay worker that publishes events and retries failures
- refresh the store quote use-case documentation and extend unit coverage for the new worker behavior

## Testing
- mvn -pl application test

------
https://chatgpt.com/codex/tasks/task_e_68d95410d19c8329b51d5c448e49f6a8