### PR TITLE
Align admin outbox worker batch size update with generated API

### DIFF
--- a/api/src/main/resources/openapi/admin-api.yaml
+++ b/api/src/main/resources/openapi/admin-api.yaml
@@ -119,6 +119,21 @@ paths:
       responses:
         '204':
           description: Posts successfully reset
+  /admin/outbox/worker/batch-size:
+    post:
+      tags:
+        - Admin
+      summary: Update the outbox worker batch size
+      operationId: updateOutboxWorkerBatchSize
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: './components/schemas.yaml#/components/schemas/UpdateOutboxBatchSizeRequest'
+      responses:
+        '204':
+          description: Outbox worker batch size successfully updated
   /admin/export:
     get:
       tags:

--- a/api/src/main/resources/openapi/components/schemas.yaml
+++ b/api/src/main/resources/openapi/components/schemas.yaml
@@ -34,6 +34,16 @@ components:
         spotifyArtistId:
           type: string
           description: Spotify identifier of the artist
+    UpdateOutboxBatchSizeRequest:
+      type: object
+      required:
+        - batchSize
+      properties:
+        batchSize:
+          type: integer
+          format: int32
+          minimum: 1
+          description: Number of outbox events processed per worker execution
     Artist:
       type: object
       required:

--- a/api/src/main/resources/openapi/song-quotes-service.yaml
+++ b/api/src/main/resources/openapi/song-quotes-service.yaml
@@ -21,6 +21,8 @@ paths:
     $ref: './admin-api.yaml#/paths/~1admin~1quotes~1reset-posts'
   /admin/quote/{id}:
     $ref: './admin-api.yaml#/paths/~1admin~1quote~1{id}'
+  /admin/outbox/worker/batch-size:
+    $ref: './admin-api.yaml#/paths/~1admin~1outbox~1worker~1batch-size'
   /admin/export:
     $ref: './admin-api.yaml#/paths/~1admin~1export'
   /quotes:
@@ -47,3 +49,5 @@ components:
       $ref: './components/schemas.yaml#/components/schemas/ArtistTrack'
     ArtistQuoteCount:
       $ref: './components/schemas.yaml#/components/schemas/ArtistQuoteCount'
+    UpdateOutboxBatchSizeRequest:
+      $ref: './components/schemas.yaml#/components/schemas/UpdateOutboxBatchSizeRequest'

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -3,6 +3,7 @@ package com.xavelo.sqs.adapter.in.http.admin;
 import com.xavelo.sqs.adapter.in.http.admin.mapper.AdminQuoteMapper;
 import com.xavelo.sqs.application.api.AdminApi;
 import com.xavelo.sqs.application.api.model.QuoteDto;
+import com.xavelo.sqs.application.api.model.UpdateOutboxBatchSizeRequestDto;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.application.service.AdminService;
 import com.xavelo.sqs.application.service.QuoteHelper;
@@ -87,6 +88,13 @@ public class AdminController implements AdminApi {
             return ResponseEntity.badRequest().build();
         }
         patchQuoteUseCase.patchQuote(id, quote);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> updateOutboxWorkerBatchSize(@Valid @RequestBody UpdateOutboxBatchSizeRequestDto updateOutboxBatchSizeRequestDto) {
+        int batchSize = updateOutboxBatchSizeRequestDto.getBatchSize();
+        adminService.updateOutboxWorkerBatchSize(batchSize);
         return ResponseEntity.noContent().build();
     }
 

--- a/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
@@ -23,17 +23,20 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
     private final UpdateQuotePort updateQuotePort;
     private final ResetQuoteHitsPort resetQuoteHitsPort;
     private final ResetQuotePostsPort resetQuotePostsPort;
+    private final QuoteEventRelayWorker quoteEventRelayWorker;
 
     public AdminService(LoadQuotePort loadQuotePort,
                         DeleteQuotePort deleteQuotePort,
                         UpdateQuotePort updateQuotePort,
                         ResetQuoteHitsPort resetQuoteHitsPort,
-                        ResetQuotePostsPort resetQuotePostsPort) {
+                        ResetQuotePostsPort resetQuotePostsPort,
+                        QuoteEventRelayWorker quoteEventRelayWorker) {
         this.loadQuotePort = loadQuotePort;
         this.deleteQuotePort = deleteQuotePort;
         this.updateQuotePort = updateQuotePort;
         this.resetQuoteHitsPort = resetQuoteHitsPort;
         this.resetQuotePostsPort = resetQuotePostsPort;
+        this.quoteEventRelayWorker = quoteEventRelayWorker;
     }
 
     @Override
@@ -74,5 +77,9 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
     @Override
     public void resetQuotePosts() {
         resetQuotePostsPort.resetQuotePosts();
+    }
+
+    public void updateOutboxWorkerBatchSize(int batchSize) {
+        quoteEventRelayWorker.updateBatchSize(batchSize);
     }
 }


### PR DESCRIPTION
## Summary
- expose the admin outbox worker batch size endpoint and payload through the shared OpenAPI documents
- update the AdminController to consume the generated UpdateOutboxBatchSizeRequestDto and forward the batch size to the service layer
- delegate to AdminService and QuoteEventRelayWorker so the worker batch size can be adjusted dynamically

## Testing
- mvn -pl application -am compile

------
https://chatgpt.com/codex/tasks/task_e_68d973a609a083298ff7e439a3072131