### PR TITLE
Annotate HTTP controllers with Adapter stereotype

### DIFF
--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -1,5 +1,6 @@
 package com.xavelo.sqs.adapter.in.http.admin;
 
+import com.xavelo.sqs.adapter.Adapter;
 import com.xavelo.sqs.adapter.in.http.admin.mapper.AdminQuoteMapper;
 import com.xavelo.sqs.application.api.AdminApi;
 import com.xavelo.sqs.application.api.model.QuoteDto;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Adapter
 @RestController
 public class AdminController implements AdminApi {
 

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
@@ -1,5 +1,6 @@
 package com.xavelo.sqs.adapter.in.http.artist;
 
+import com.xavelo.sqs.adapter.Adapter;
 import com.xavelo.sqs.adapter.in.http.artist.mapper.ArtistMapper;
 import com.xavelo.sqs.application.api.ArtistApi;
 import com.xavelo.sqs.application.api.model.ArtistDto;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Adapter
 @RestController
 @RequestMapping("/api")
 public class ArtistController implements ArtistApi {

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/ping/PingController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/ping/PingController.java
@@ -1,9 +1,11 @@
 package com.xavelo.sqs.adapter.in.http.ping;
 
+import com.xavelo.sqs.adapter.Adapter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Adapter
 @RestController
 @RequestMapping("/api")
 public class PingController {

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
@@ -1,5 +1,6 @@
 package com.xavelo.sqs.adapter.in.http.quote;
 
+import com.xavelo.sqs.adapter.Adapter;
 import com.xavelo.sqs.adapter.in.http.quote.mapper.QuoteMapper;
 import com.xavelo.sqs.application.api.QuoteApi;
 import com.xavelo.sqs.application.api.model.QuoteDto;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Adapter
 @RestController
 @RequestMapping("/api")
 public class QuoteController implements QuoteApi {

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/secure/SecurePingController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/secure/SecurePingController.java
@@ -1,11 +1,13 @@
 package com.xavelo.sqs.adapter.in.http.secure;
 
+import com.xavelo.sqs.adapter.Adapter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Adapter
 @RestController
 @RequestMapping("/api/secure")
 public class SecurePingController {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteCreatedKafkaAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteCreatedKafkaAdapter.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.out.PublishQuoteCreatedPort;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.stereotype.Component;
+import com.xavelo.sqs.adapter.Adapter;
 
-@Component
+@Adapter
 public class QuoteCreatedKafkaAdapter implements PublishQuoteCreatedPort {
 
     private final KafkaTemplate<String, String> kafkaTemplate;

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteHitKafkaAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteHitKafkaAdapter.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.out.PublishQuoteHitPort;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.stereotype.Component;
+import com.xavelo.sqs.adapter.Adapter;
 
-@Component
+@Adapter
 public class QuoteHitKafkaAdapter implements PublishQuoteHitPort {
 
     private final KafkaTemplate<String, String> kafkaTemplate;

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
@@ -1,17 +1,16 @@
 package com.xavelo.sqs.adapter.out.metrics;
 
+import com.xavelo.sqs.adapter.Adapter;
 import com.xavelo.sqs.port.out.MetricsPort;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.springframework.stereotype.Component;
-
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
  * Adapter using Micrometer to record metrics.
  */
-@Component
+@Adapter
 public class MicrometerMetricsAdapter implements MetricsPort {
 
     private static final String TOTAL_HITS_METRIC_NAME = "quote_hits_total";

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
@@ -11,11 +11,11 @@ import com.xavelo.sqs.application.service.QuoteService;
 import com.xavelo.sqs.port.out.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.stereotype.Component;
+import com.xavelo.sqs.adapter.Adapter;
 
 import java.util.List;
 
-@Component
+@Adapter
 public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort, ResetQuoteHitsPort, ResetQuotePostsPort {
 
     private static final Logger logger = LogManager.getLogger(MysqlAdapter.class);

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxAdapter.java
@@ -7,14 +7,14 @@ import com.xavelo.sqs.application.domain.QuoteEvent;
 import com.xavelo.sqs.application.domain.QuoteEventType;
 import com.xavelo.sqs.port.out.QuoteEventOutboxPort;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Component;
+import com.xavelo.sqs.adapter.Adapter;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Component
+@Adapter
 public class QuoteEventOutboxAdapter implements QuoteEventOutboxPort {
 
     private final QuoteEventOutboxRepository repository;

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxMetrics.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxMetrics.java
@@ -2,7 +2,7 @@ package com.xavelo.sqs.adapter.out.mysql.outbox;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.springframework.stereotype.Component;
+import com.xavelo.sqs.adapter.Adapter;
 
 import java.time.LocalDateTime;
 
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
  * Prometheus and visualized in Grafana to monitor the relay lag and
  * inflight deliveries.</p>
  */
-@Component
+@Adapter
 public class QuoteEventOutboxMetrics {
 
     static final String OUTBOX_READY_METRIC = "quote_outbox_ready_events";

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/SpotifyAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/SpotifyAdapter.java
@@ -7,15 +7,14 @@ import com.xavelo.sqs.adapter.out.spotify.client.SpotifySearchResponse;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyTopTracksClient;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyTopTracksResponse;
 import com.xavelo.sqs.application.domain.Artist;
+import com.xavelo.sqs.adapter.Adapter;
 import com.xavelo.sqs.port.out.metadata.GetArtistMetadataPort;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.stereotype.Component;
-
 import java.util.Collections;
 import java.util.List;
 
-@Component
+@Adapter
 public class SpotifyAdapter implements GetArtistMetadataPort {
 
     private static final Logger logger = LogManager.getLogger(SpotifyAdapter.class);

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/client/token/SpotifyAuthService.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/client/token/SpotifyAuthService.java
@@ -1,12 +1,12 @@
 package com.xavelo.sqs.adapter.out.spotify.client.token;
 
+import com.xavelo.sqs.adapter.Adapter;
 import com.xavelo.sqs.configuration.spotify.SpotifyProperties;
-import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import java.util.Base64;
 
-@Service
+@Adapter
 public class SpotifyAuthService {
 
     private final SpotifyTokenClient spotifyTokenClient;


### PR DESCRIPTION
## Summary
- add the shared `@Adapter` stereotype to the REST controllers under the HTTP inbound adapters to keep all adapters consistent

## Testing
- `./mvnw -pl application test` *(fails: Maven wrapper cannot download dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe490ee4c8329bdf24f971acc6957