### PR TITLE
Enable adapter metrics aspect

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>


### PR DESCRIPTION
## Summary
- add spring-boot-starter-aop dependency so AdapterMetricsAspect is proxied and meters are emitted

## Testing
- ./mvnw -pl application -am test *(fails: Maven wrapper could not download distribution because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dff7c14d0c83299d38b646062b6d9e