### PR TITLE
Add adapter invocation metrics across adapters

### DIFF
--- a/application/src/main/java/com/xavelo/sqs/adapter/AdapterMetrics.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/AdapterMetrics.java
@@ -53,7 +53,9 @@ public class AdapterMetrics {
 
     public enum Type {
         HTTP,
-        KAFKA
+        KAFKA,
+        DATABASE,
+        METRICS
     }
 
     public enum Direction {

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -1,6 +1,7 @@
 package com.xavelo.sqs.adapter.in.http.admin;
 
 import com.xavelo.sqs.adapter.Adapter;
+import com.xavelo.sqs.adapter.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.in.http.admin.mapper.AdminQuoteMapper;
 import com.xavelo.sqs.application.api.AdminApi;
 import com.xavelo.sqs.application.api.model.QuoteDto;
@@ -20,6 +21,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+
+import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.IN;
+import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController
@@ -50,6 +54,7 @@ public class AdminController implements AdminApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "create-quote", direction = IN, type = HTTP)
     public ResponseEntity<Long> createQuote(@Valid @RequestBody QuoteDto quoteDto) {
         Quote quote = quoteMapper.toDomain(quoteDto);
         Long id = storeQuoteUseCase.storeQuote(quote);
@@ -57,6 +62,7 @@ public class AdminController implements AdminApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "create-quotes", direction = IN, type = HTTP)
     public ResponseEntity<List<Long>> createQuotes(@Valid @RequestBody List<@Valid QuoteDto> quoteDtos) {
         List<Quote> quotes = quoteMapper.toDomain(quoteDtos);
         List<Long> ids = storeQuoteUseCase.storeQuotes(quotes);
@@ -64,12 +70,14 @@ public class AdminController implements AdminApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "delete-quote", direction = IN, type = HTTP)
     public ResponseEntity<Void> deleteQuote(@PathVariable Long id) {
         adminService.deleteQuote(id);
         return ResponseEntity.noContent().build();
     }
 
     @Override
+    @CountAdapterInvocation(name = "update-quote", direction = IN, type = HTTP)
     public ResponseEntity<Void> updateQuote(@PathVariable Long id, @Valid @RequestBody QuoteDto quoteDto) {
         Quote quote = quoteMapper.toDomain(quoteDto);
         if (containsRestrictedFields(quote)) {
@@ -84,6 +92,7 @@ public class AdminController implements AdminApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "patch-quote", direction = IN, type = HTTP)
     public ResponseEntity<Void> patchQuote(@PathVariable Long id, @Valid @RequestBody QuoteDto quoteDto) {
         Quote quote = quoteMapper.toDomain(quoteDto);
         if (containsRestrictedFields(quote)) {
@@ -94,6 +103,7 @@ public class AdminController implements AdminApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "update-outbox-worker-batch-size", direction = IN, type = HTTP)
     public ResponseEntity<Void> updateOutboxWorkerBatchSize(@Valid @RequestBody UpdateOutboxBatchSizeRequestDto updateOutboxBatchSizeRequestDto) {
         int batchSize = updateOutboxBatchSizeRequestDto.getBatchSize();
         adminService.updateOutboxWorkerBatchSize(batchSize);
@@ -101,18 +111,21 @@ public class AdminController implements AdminApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "export-quotes", direction = IN, type = HTTP)
     public ResponseEntity<String> exportQuotes() {
         String sql = adminService.exportQuotesAsSql();
         return ResponseEntity.ok(sql);
     }
 
     @Override
+    @CountAdapterInvocation(name = "reset-quote-hits", direction = IN, type = HTTP)
     public ResponseEntity<Void> resetQuoteHits() {
         resetQuoteHitsUseCase.resetQuoteHits();
         return ResponseEntity.noContent().build();
     }
 
     @Override
+    @CountAdapterInvocation(name = "reset-quote-posts", direction = IN, type = HTTP)
     public ResponseEntity<Void> resetQuotePosts() {
         resetQuotePostsUseCase.resetQuotePosts();
         return ResponseEntity.noContent().build();

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
@@ -1,6 +1,7 @@
 package com.xavelo.sqs.adapter.in.http.artist;
 
 import com.xavelo.sqs.adapter.Adapter;
+import com.xavelo.sqs.adapter.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.in.http.artist.mapper.ArtistMapper;
 import com.xavelo.sqs.application.api.ArtistApi;
 import com.xavelo.sqs.application.api.model.ArtistDto;
@@ -15,6 +16,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+
+import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.IN;
+import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController
@@ -33,6 +37,7 @@ public class ArtistController implements ArtistApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "get-artist", direction = IN, type = HTTP)
     public ResponseEntity<ArtistDto> getArtist(@PathVariable String id) {
         Artist artist = getArtistUseCase.getArtist(id);
         return artist != null
@@ -41,6 +46,7 @@ public class ArtistController implements ArtistApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "get-artists", direction = IN, type = HTTP)
     public ResponseEntity<List<ArtistQuoteCountDto>> getArtists() {
         List<ArtistQuoteCount> artists = getArtistQuoteCountsUseCase.getArtistQuoteCounts();
         return ResponseEntity.ok(artistMapper.toQuoteCountDtos(artists));

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/ping/PingController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/ping/PingController.java
@@ -1,9 +1,13 @@
 package com.xavelo.sqs.adapter.in.http.ping;
 
 import com.xavelo.sqs.adapter.Adapter;
+import com.xavelo.sqs.adapter.CountAdapterInvocation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.IN;
+import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController
@@ -14,6 +18,7 @@ public class PingController {
     private String podName;
 
     @GetMapping("/ping")
+    @CountAdapterInvocation(name = "ping", direction = IN, type = HTTP)
     public ResponseEntity<String> ping() {
         return ResponseEntity.ok("pong from " + podName);
     }

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
@@ -48,12 +48,14 @@ public class QuoteController implements QuoteApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "get-quotes", direction = IN, type = HTTP)
     public ResponseEntity<List<QuoteDto>> getQuotes() {
         List<Quote> quotes = getQuotesUseCase.getQuotes();
         return ResponseEntity.ok(quoteMapper.toDtos(quotes));
     }
 
     @Override
+    @CountAdapterInvocation(name = "count-quotes", direction = IN, type = HTTP)
     public ResponseEntity<Long> getQuotesCount() {
         Long count = countQuotesUseCase.countQuotes();
         return ResponseEntity.ok(count);
@@ -69,6 +71,7 @@ public class QuoteController implements QuoteApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "get-quote", direction = IN, type = HTTP)
     public ResponseEntity<QuoteDto> getQuote(@PathVariable("id") Long id) {
         Quote quote = getQuoteUseCase.getQuote(id);
         return quote != null
@@ -77,6 +80,7 @@ public class QuoteController implements QuoteApi {
     }
 
     @Override
+    @CountAdapterInvocation(name = "top10-quotes", direction = IN, type = HTTP)
     public ResponseEntity<List<QuoteDto>> getTop10Quotes() {
         List<Quote> quotes = getTop10QuotesUseCase.getTop10Quotes();
         return ResponseEntity.ok(quoteMapper.toDtos(quotes));

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/secure/SecurePingController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/secure/SecurePingController.java
@@ -1,11 +1,15 @@
 package com.xavelo.sqs.adapter.in.http.secure;
 
 import com.xavelo.sqs.adapter.Adapter;
+import com.xavelo.sqs.adapter.CountAdapterInvocation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.IN;
+import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController
@@ -16,6 +20,7 @@ public class SecurePingController {
     private String podName;
 
     @GetMapping("/ping")
+    @CountAdapterInvocation(name = "secure-ping", direction = IN, type = HTTP)
     public ResponseEntity<String> ping() {
         return ResponseEntity.ok("pong from " + podName);
     }

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteCreatedKafkaAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteCreatedKafkaAdapter.java
@@ -2,10 +2,14 @@ package com.xavelo.sqs.adapter.out.kafka;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xavelo.sqs.adapter.CountAdapterInvocation;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.out.PublishQuoteCreatedPort;
 import org.springframework.kafka.core.KafkaTemplate;
 import com.xavelo.sqs.adapter.Adapter;
+
+import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
+import static com.xavelo.sqs.adapter.AdapterMetrics.Type.KAFKA;
 
 @Adapter
 public class QuoteCreatedKafkaAdapter implements PublishQuoteCreatedPort {
@@ -21,6 +25,7 @@ public class QuoteCreatedKafkaAdapter implements PublishQuoteCreatedPort {
     }
 
     @Override
+    @CountAdapterInvocation(name = "publish-quote-created", direction = OUT, type = KAFKA)
     public void publishQuoteCreated(Quote quote) {
         try {
             String payload = objectMapper.writeValueAsString(quote);

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteHitKafkaAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteHitKafkaAdapter.java
@@ -2,10 +2,14 @@ package com.xavelo.sqs.adapter.out.kafka;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xavelo.sqs.adapter.CountAdapterInvocation;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.out.PublishQuoteHitPort;
 import org.springframework.kafka.core.KafkaTemplate;
 import com.xavelo.sqs.adapter.Adapter;
+
+import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
+import static com.xavelo.sqs.adapter.AdapterMetrics.Type.KAFKA;
 
 @Adapter
 public class QuoteHitKafkaAdapter implements PublishQuoteHitPort {
@@ -21,6 +25,7 @@ public class QuoteHitKafkaAdapter implements PublishQuoteHitPort {
     }
 
     @Override
+    @CountAdapterInvocation(name = "publish-quote-hit", direction = OUT, type = KAFKA)
     public void publishQuoteHit(Quote quote) {
         try {
             String payload = objectMapper.writeValueAsString(quote);

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
@@ -1,11 +1,15 @@
 package com.xavelo.sqs.adapter.out.metrics;
 
 import com.xavelo.sqs.adapter.Adapter;
+import com.xavelo.sqs.adapter.CountAdapterInvocation;
 import com.xavelo.sqs.port.out.MetricsPort;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
+import static com.xavelo.sqs.adapter.AdapterMetrics.Type.METRICS;
 
 /**
  * Adapter using Micrometer to record metrics.
@@ -33,16 +37,19 @@ public class MicrometerMetricsAdapter implements MetricsPort {
     }
 
     @Override
+    @CountAdapterInvocation(name = "increment-total-hits", direction = OUT, type = METRICS)
     public void incrementTotalHits() {
         totalHitsCounter.increment();
     }
 
     @Override
+    @CountAdapterInvocation(name = "increment-stored-quotes", direction = OUT, type = METRICS)
     public void incrementStoredQuotes() {
         storedQuotesCounter.increment();
     }
 
     @Override
+    @CountAdapterInvocation(name = "increment-quote-hits", direction = OUT, type = METRICS)
     public void incrementQuoteHits(Long quoteId) {
         if (quoteId == null) {
             return;

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxMetrics.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxMetrics.java
@@ -3,8 +3,12 @@ package com.xavelo.sqs.adapter.out.mysql.outbox;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import com.xavelo.sqs.adapter.Adapter;
+import com.xavelo.sqs.adapter.CountAdapterInvocation;
 
 import java.time.LocalDateTime;
+
+import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
+import static com.xavelo.sqs.adapter.AdapterMetrics.Type.METRICS;
 
 /**
  * Publishes Micrometer gauges that expose the state of the quote event outbox.
@@ -39,16 +43,19 @@ public class QuoteEventOutboxMetrics {
                 .register(meterRegistry);
     }
 
+    @CountAdapterInvocation(name = "count-ready-outbox-events", direction = OUT, type = METRICS)
     double countReadyEvents() {
         LocalDateTime now = LocalDateTime.now();
         return repository.countByStatusAndAvailableAtLessThanEqual(QuoteEventStatus.PENDING, now);
     }
 
+    @CountAdapterInvocation(name = "count-delayed-outbox-events", direction = OUT, type = METRICS)
     double countDelayedEvents() {
         LocalDateTime now = LocalDateTime.now();
         return repository.countByStatusAndAvailableAtAfter(QuoteEventStatus.PENDING, now);
     }
 
+    @CountAdapterInvocation(name = "count-processing-outbox-events", direction = OUT, type = METRICS)
     double countProcessingEvents() {
         return repository.countByStatus(QuoteEventStatus.PROCESSING);
     }

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/SpotifyAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/SpotifyAdapter.java
@@ -1,5 +1,6 @@
 package com.xavelo.sqs.adapter.out.spotify;
 
+import com.xavelo.sqs.adapter.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyArtistClient;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyArtistResponse;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifySearchClient;
@@ -13,6 +14,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import java.util.Collections;
 import java.util.List;
+
+import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
+import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
 
 @Adapter
 public class SpotifyAdapter implements GetArtistMetadataPort {
@@ -30,6 +34,7 @@ public class SpotifyAdapter implements GetArtistMetadataPort {
     }
 
     @Override
+    @CountAdapterInvocation(name = "get-artist-metadata", direction = OUT, type = HTTP)
     public Artist getArtistMetadata(String artistName) {
         SpotifySearchResponse searchResponse = spotifySearchClient.searchArtist(artistName);
         if (searchResponse != null && searchResponse.artists() != null && searchResponse.artists().items() != null && !searchResponse.artists().items().isEmpty()) {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/client/token/SpotifyAuthService.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/client/token/SpotifyAuthService.java
@@ -1,10 +1,14 @@
 package com.xavelo.sqs.adapter.out.spotify.client.token;
 
 import com.xavelo.sqs.adapter.Adapter;
+import com.xavelo.sqs.adapter.CountAdapterInvocation;
 import com.xavelo.sqs.configuration.spotify.SpotifyProperties;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import java.util.Base64;
+
+import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
+import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
 
 @Adapter
 public class SpotifyAuthService {
@@ -17,6 +21,7 @@ public class SpotifyAuthService {
         this.spotifyProperties = spotifyProperties;
     }
 
+    @CountAdapterInvocation(name = "get-spotify-access-token", direction = OUT, type = HTTP)
     public String getAccessToken() {
         String authString = spotifyProperties.getClientId() + ":" + spotifyProperties.getClientSecret();
         String encodedAuthString = Base64.getEncoder().encodeToString(authString.getBytes());


### PR DESCRIPTION
## Summary
- extend adapter metrics types to cover database and metrics integrations
- instrument every HTTP, Kafka, metrics, Spotify, and MySQL adapter with `@CountAdapterInvocation`

## Testing
- `./mvnw -pl application test` *(fails: network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e0058b8cc48329a4673266946dbc74