### PR TITLE
Log adapter durations for easier inspection

### DIFF
--- a/application/src/main/java/com/xavelo/sqs/adapter/AdapterMetrics.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/AdapterMetrics.java
@@ -35,11 +35,18 @@ public class AdapterMetrics {
         try {
             timeAdapterDuration(metricName, type, direction, Duration.between(start, end));
         } catch (DateTimeException | ArithmeticException e) {
-            logger.error("Exception");
+            logger.error("Failed to compute adapter duration for {} - {} - {}", metricName, type, direction, e);
         }
     }
 
     public static void timeAdapterDuration(String adapterName, Type type, Direction direction, Duration duration) {
+        logger.info(
+            "adapter duration: {} - {} - {} -> {} ms",
+            adapterName,
+            type.name(),
+            direction.name(),
+            duration.toMillis()
+        );
         Timer.builder("adapter.duration")
             .tags(of(
                     Tag.of("name", adapterName),


### PR DESCRIPTION
## Summary
- log a message with the measured adapter duration so operators can quickly inspect timings
- improve the error log when duration computation fails

## Testing
- `./mvnw -pl application test` *(fails: Network is unreachable while downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68e00c348eb08329b7910e9fda877c44