### PR TITLE
Extract adapter metrics into reusable module

### DIFF
--- a/adapter-metrics/pom.xml
+++ b/adapter-metrics/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.xavelo.sqs</groupId>
+        <artifactId>song-quotes-service-parent</artifactId>
+        <version>TRUNK-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>adapter-metrics</artifactId>
+    <name>adapter-metrics</name>
+    <description>Reusable annotations and metrics aspect for adapter instrumentation</description>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/Adapter.java
+++ b/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/Adapter.java
@@ -1,0 +1,19 @@
+package com.xavelo.adaptermetrics;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface Adapter {
+    @AliasFor(annotation = Component.class)
+    String value() default "";
+}

--- a/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/AdapterMetrics.java
+++ b/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/AdapterMetrics.java
@@ -1,0 +1,79 @@
+package com.xavelo.adaptermetrics;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.Instant;
+
+import static io.micrometer.core.instrument.Tags.of;
+import static java.util.Locale.UK;
+
+public final class AdapterMetrics {
+
+    private static final Logger logger = LogManager.getLogger(AdapterMetrics.class);
+
+    private AdapterMetrics() {
+    }
+
+    public static void countAdapterInvocation(String adapterName, Type type, Direction direction, Result result) {
+        Metrics.counter(
+                "adapter.invocation",
+                of(
+                        Tag.of("name", adapterName),
+                        Tag.of("type", type.name().toLowerCase(UK)),
+                        Tag.of("direction", direction.name().toLowerCase(UK)),
+                        Tag.of("result", result.name().toLowerCase(UK))
+                )
+            )
+            .increment();
+    }
+
+    public static void timeAdapterDuration(String metricName, Type type, Direction direction, Instant start, Instant end) {
+        try {
+            timeAdapterDuration(metricName, type, direction, Duration.between(start, end));
+        } catch (DateTimeException | ArithmeticException e) {
+            logger.error("Failed to compute adapter duration for {} - {} - {}", metricName, type, direction, e);
+        }
+    }
+
+    public static void timeAdapterDuration(String adapterName, Type type, Direction direction, Duration duration) {
+        logger.info(
+            "adapter duration: {} - {} - {} -> {} ms",
+            adapterName,
+            type.name(),
+            direction.name(),
+            duration.toMillis()
+        );
+        Timer.builder("adapter.duration")
+            .tags(of(
+                    Tag.of("name", adapterName),
+                    Tag.of("type", type.name().toLowerCase(UK)),
+                    Tag.of("direction", direction.name().toLowerCase(UK))
+            ))
+            .publishPercentiles(0.95, 0.99)
+            .register(Metrics.globalRegistry)
+            .record(duration);
+    }
+
+    public enum Type {
+        HTTP,
+        KAFKA,
+        DATABASE,
+        METRICS
+    }
+
+    public enum Direction {
+        IN,
+        OUT
+    }
+
+    public enum Result {
+        SUCCESS,
+        ERROR
+    }
+}

--- a/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/AdapterMetricsAspect.java
+++ b/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/AdapterMetricsAspect.java
@@ -1,0 +1,34 @@
+package com.xavelo.adaptermetrics;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+import java.time.Instant;
+
+@Aspect
+public class AdapterMetricsAspect {
+
+    @Around("@annotation(annotation)")
+    public Object countAdapterInvocation(ProceedingJoinPoint joinPoint, CountAdapterInvocation annotation) throws Throwable {
+        Instant start = Instant.now();
+        try {
+            Object proceed = joinPoint.proceed();
+            count(annotation, AdapterMetrics.Result.SUCCESS);
+            return proceed;
+        } catch (Throwable t) {
+            count(annotation, AdapterMetrics.Result.ERROR);
+            throw t;
+        } finally {
+            time(annotation, start, Instant.now());
+        }
+    }
+
+    private void count(CountAdapterInvocation annotation, AdapterMetrics.Result result) {
+        AdapterMetrics.countAdapterInvocation(annotation.name(), annotation.type(), annotation.direction(), result);
+    }
+
+    private void time(CountAdapterInvocation annotation, Instant start, Instant end) {
+        AdapterMetrics.timeAdapterDuration(annotation.name(), annotation.type(), annotation.direction(), start, end);
+    }
+}

--- a/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/CountAdapterInvocation.java
+++ b/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/CountAdapterInvocation.java
@@ -1,0 +1,15 @@
+package com.xavelo.adaptermetrics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CountAdapterInvocation {
+
+    String name();
+    AdapterMetrics.Direction direction();
+    AdapterMetrics.Type type();
+}

--- a/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/autoconfigure/AdapterMetricsAutoConfiguration.java
+++ b/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/autoconfigure/AdapterMetricsAutoConfiguration.java
@@ -1,0 +1,16 @@
+package com.xavelo.adaptermetrics.autoconfigure;
+
+import com.xavelo.adaptermetrics.AdapterMetricsAspect;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+public class AdapterMetricsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public AdapterMetricsAspect adapterMetricsAspect() {
+        return new AdapterMetricsAspect();
+    }
+}

--- a/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/autoconfigure/EnableAdapterMetrics.java
+++ b/adapter-metrics/src/main/java/com/xavelo/adaptermetrics/autoconfigure/EnableAdapterMetrics.java
@@ -1,0 +1,16 @@
+package com.xavelo.adaptermetrics.autoconfigure;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(AdapterMetricsAutoConfiguration.class)
+public @interface EnableAdapterMetrics {
+}

--- a/adapter-metrics/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/adapter-metrics/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.xavelo.adaptermetrics.autoconfigure.AdapterMetricsAutoConfiguration

--- a/adapter-metrics/src/test/java/com/xavelo/adaptermetrics/AdapterMetricsAspectTest.java
+++ b/adapter-metrics/src/test/java/com/xavelo/adaptermetrics/AdapterMetricsAspectTest.java
@@ -1,0 +1,81 @@
+package com.xavelo.adaptermetrics;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdapterMetricsAspectTest {
+
+    @Mock
+    private ProceedingJoinPoint joinPoint;
+
+    private AdapterMetricsAspect aspect;
+
+    private SimpleMeterRegistry meterRegistry;
+
+    private CountAdapterInvocation annotation;
+
+    @BeforeEach
+    void setUp() {
+        aspect = new AdapterMetricsAspect();
+        meterRegistry = new SimpleMeterRegistry();
+        Metrics.globalRegistry.add(meterRegistry);
+        annotation = new CountAdapterInvocation() {
+            @Override
+            public String name() {
+                return "test-adapter";
+            }
+
+            @Override
+            public AdapterMetrics.Direction direction() {
+                return AdapterMetrics.Direction.OUT;
+            }
+
+            @Override
+            public AdapterMetrics.Type type() {
+                return AdapterMetrics.Type.HTTP;
+            }
+
+            @Override
+            public Class<? extends java.lang.annotation.Annotation> annotationType() {
+                return CountAdapterInvocation.class;
+            }
+        };
+    }
+
+    @AfterEach
+    void tearDown() {
+        Metrics.globalRegistry.remove(meterRegistry);
+        meterRegistry.close();
+    }
+
+    @Test
+    void countAdapterInvocation_recordsErrorOnThrowable() throws Throwable {
+        Error error = new Error("boom");
+        when(joinPoint.proceed()).thenThrow(error);
+
+        assertThatThrownBy(() -> aspect.countAdapterInvocation(joinPoint, annotation))
+                .isSameAs(error);
+
+        double errorCount = meterRegistry.get("adapter.invocation")
+                .tag("name", "test-adapter")
+                .tag("type", "http")
+                .tag("direction", "out")
+                .tag("result", "error")
+                .counter()
+                .count();
+
+        assertThat(errorCount).isEqualTo(1.0d);
+    }
+}

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -19,6 +19,11 @@
     <dependencies>
         <dependency>
             <groupId>com.xavelo.sqs</groupId>
+            <artifactId>adapter-metrics</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.xavelo.sqs</groupId>
             <artifactId>song-quotes-service-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -1,7 +1,7 @@
 package com.xavelo.sqs.adapter.in.http.admin;
 
-import com.xavelo.sqs.adapter.Adapter;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.in.http.admin.mapper.AdminQuoteMapper;
 import com.xavelo.sqs.application.api.AdminApi;
 import com.xavelo.sqs.application.api.model.QuoteDto;
@@ -22,8 +22,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.IN;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.IN;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
@@ -1,7 +1,7 @@
 package com.xavelo.sqs.adapter.in.http.artist;
 
-import com.xavelo.sqs.adapter.Adapter;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.in.http.artist.mapper.ArtistMapper;
 import com.xavelo.sqs.application.api.ArtistApi;
 import com.xavelo.sqs.application.api.model.ArtistDto;
@@ -17,8 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.IN;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.IN;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/ping/PingController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/ping/PingController.java
@@ -1,13 +1,13 @@
 package com.xavelo.sqs.adapter.in.http.ping;
 
-import com.xavelo.sqs.adapter.Adapter;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.IN;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.IN;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
@@ -1,7 +1,7 @@
 package com.xavelo.sqs.adapter.in.http.quote;
 
-import com.xavelo.sqs.adapter.Adapter;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.in.http.quote.mapper.QuoteMapper;
 import com.xavelo.sqs.application.api.QuoteApi;
 import com.xavelo.sqs.application.api.model.QuoteDto;
@@ -18,8 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.IN;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.IN;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/secure/SecurePingController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/secure/SecurePingController.java
@@ -1,15 +1,15 @@
 package com.xavelo.sqs.adapter.in.http.secure;
 
-import com.xavelo.sqs.adapter.Adapter;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.IN;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.IN;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteCreatedKafkaAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteCreatedKafkaAdapter.java
@@ -2,14 +2,14 @@ package com.xavelo.sqs.adapter.out.kafka;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.out.PublishQuoteCreatedPort;
 import org.springframework.kafka.core.KafkaTemplate;
-import com.xavelo.sqs.adapter.Adapter;
+import com.xavelo.adaptermetrics.Adapter;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.KAFKA;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.KAFKA;
 
 @Adapter
 public class QuoteCreatedKafkaAdapter implements PublishQuoteCreatedPort {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteHitKafkaAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteHitKafkaAdapter.java
@@ -2,14 +2,14 @@ package com.xavelo.sqs.adapter.out.kafka;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.out.PublishQuoteHitPort;
 import org.springframework.kafka.core.KafkaTemplate;
-import com.xavelo.sqs.adapter.Adapter;
+import com.xavelo.adaptermetrics.Adapter;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.KAFKA;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.KAFKA;
 
 @Adapter
 public class QuoteHitKafkaAdapter implements PublishQuoteHitPort {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
@@ -1,15 +1,15 @@
 package com.xavelo.sqs.adapter.out.metrics;
 
-import com.xavelo.sqs.adapter.Adapter;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import com.xavelo.sqs.port.out.MetricsPort;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.METRICS;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.METRICS;
 
 /**
  * Adapter using Micrometer to record metrics.

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
@@ -2,8 +2,8 @@ package com.xavelo.sqs.adapter.out.mysql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.xavelo.sqs.adapter.Adapter;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.out.mysql.spotify.SpotifyArtistMetadataEntity;
 import com.xavelo.sqs.adapter.out.mysql.spotify.SpotifyArtistMetadataRepository;
 import com.xavelo.sqs.application.domain.Artist;
@@ -16,8 +16,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.DATABASE;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.DATABASE;
 
 @Adapter
 public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort, ResetQuoteHitsPort, ResetQuotePostsPort {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxAdapter.java
@@ -2,8 +2,8 @@ package com.xavelo.sqs.adapter.out.mysql.outbox;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.xavelo.sqs.adapter.Adapter;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.application.domain.QuoteEvent;
 import com.xavelo.sqs.application.domain.QuoteEventType;
@@ -15,8 +15,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.DATABASE;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.DATABASE;
 
 @Adapter
 public class QuoteEventOutboxAdapter implements QuoteEventOutboxPort {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxMetrics.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxMetrics.java
@@ -2,13 +2,13 @@ package com.xavelo.sqs.adapter.out.mysql.outbox;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import com.xavelo.sqs.adapter.Adapter;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 
 import java.time.LocalDateTime;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.METRICS;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.METRICS;
 
 /**
  * Publishes Micrometer gauges that expose the state of the quote event outbox.

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/SpotifyAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/SpotifyAdapter.java
@@ -1,6 +1,6 @@
 package com.xavelo.sqs.adapter.out.spotify;
 
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyArtistClient;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyArtistResponse;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifySearchClient;
@@ -8,15 +8,15 @@ import com.xavelo.sqs.adapter.out.spotify.client.SpotifySearchResponse;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyTopTracksClient;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyTopTracksResponse;
 import com.xavelo.sqs.application.domain.Artist;
-import com.xavelo.sqs.adapter.Adapter;
+import com.xavelo.adaptermetrics.Adapter;
 import com.xavelo.sqs.port.out.metadata.GetArtistMetadataPort;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import java.util.Collections;
 import java.util.List;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 public class SpotifyAdapter implements GetArtistMetadataPort {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/client/token/SpotifyAuthService.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/client/token/SpotifyAuthService.java
@@ -1,14 +1,14 @@
 package com.xavelo.sqs.adapter.out.spotify.client.token;
 
-import com.xavelo.sqs.adapter.Adapter;
-import com.xavelo.sqs.adapter.CountAdapterInvocation;
+import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.adaptermetrics.CountAdapterInvocation;
 import com.xavelo.sqs.configuration.spotify.SpotifyProperties;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import java.util.Base64;
 
-import static com.xavelo.sqs.adapter.AdapterMetrics.Direction.OUT;
-import static com.xavelo.sqs.adapter.AdapterMetrics.Type.HTTP;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 public class SpotifyAuthService {

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>adapter-metrics</module>
         <module>api</module>
         <module>application</module>
     </modules>


### PR DESCRIPTION
## Summary
- add a new adapter-metrics module that publishes the Adapter/CountAdapterInvocation annotations, metrics utilities, and auto-configuration
- remove the duplicated annotation/aspect code from the application module and update adapters to import the shared library
- wire the new library into the build via parent/application pom changes and keep a focused aspect test in the new module

## Testing
- `mvn -pl adapter-metrics test`
- `mvn -pl application -am test`


------
https://chatgpt.com/codex/tasks/task_e_68e03d95a25c832984b93454c576405b