### PR TITLE
Rename adapter metrics module to common

### DIFF
--- a/adapter-metrics/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/adapter-metrics/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,0 @@
-com.xavelo.adaptermetrics.autoconfigure.AdapterMetricsAutoConfiguration

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -19,7 +19,7 @@
     <dependencies>
         <dependency>
             <groupId>com.xavelo.sqs</groupId>
-            <artifactId>adapter-metrics</artifactId>
+            <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -1,7 +1,7 @@
 package com.xavelo.sqs.adapter.in.http.admin;
 
-import com.xavelo.adaptermetrics.Adapter;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.in.http.admin.mapper.AdminQuoteMapper;
 import com.xavelo.sqs.application.api.AdminApi;
 import com.xavelo.sqs.application.api.model.QuoteDto;
@@ -22,8 +22,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.IN;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.IN;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/artist/ArtistController.java
@@ -1,7 +1,7 @@
 package com.xavelo.sqs.adapter.in.http.artist;
 
-import com.xavelo.adaptermetrics.Adapter;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.in.http.artist.mapper.ArtistMapper;
 import com.xavelo.sqs.application.api.ArtistApi;
 import com.xavelo.sqs.application.api.model.ArtistDto;
@@ -17,8 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.IN;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.IN;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/ping/PingController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/ping/PingController.java
@@ -1,13 +1,13 @@
 package com.xavelo.sqs.adapter.in.http.ping;
 
-import com.xavelo.adaptermetrics.Adapter;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.IN;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.IN;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
@@ -1,7 +1,7 @@
 package com.xavelo.sqs.adapter.in.http.quote;
 
-import com.xavelo.adaptermetrics.Adapter;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.in.http.quote.mapper.QuoteMapper;
 import com.xavelo.sqs.application.api.QuoteApi;
 import com.xavelo.sqs.application.api.model.QuoteDto;
@@ -18,8 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.IN;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.IN;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/secure/SecurePingController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/secure/SecurePingController.java
@@ -1,15 +1,15 @@
 package com.xavelo.sqs.adapter.in.http.secure;
 
-import com.xavelo.adaptermetrics.Adapter;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.IN;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.IN;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 @RestController

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteCreatedKafkaAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteCreatedKafkaAdapter.java
@@ -2,14 +2,14 @@ package com.xavelo.sqs.adapter.out.kafka;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.out.PublishQuoteCreatedPort;
 import org.springframework.kafka.core.KafkaTemplate;
-import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.common.metrics.Adapter;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.KAFKA;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.KAFKA;
 
 @Adapter
 public class QuoteCreatedKafkaAdapter implements PublishQuoteCreatedPort {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteHitKafkaAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/kafka/QuoteHitKafkaAdapter.java
@@ -2,14 +2,14 @@ package com.xavelo.sqs.adapter.out.kafka;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.port.out.PublishQuoteHitPort;
 import org.springframework.kafka.core.KafkaTemplate;
-import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.common.metrics.Adapter;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.KAFKA;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.KAFKA;
 
 @Adapter
 public class QuoteHitKafkaAdapter implements PublishQuoteHitPort {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
@@ -1,15 +1,15 @@
 package com.xavelo.sqs.adapter.out.metrics;
 
-import com.xavelo.adaptermetrics.Adapter;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.port.out.MetricsPort;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.METRICS;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.METRICS;
 
 /**
  * Adapter using Micrometer to record metrics.

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
@@ -2,8 +2,8 @@ package com.xavelo.sqs.adapter.out.mysql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.xavelo.adaptermetrics.Adapter;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.out.mysql.spotify.SpotifyArtistMetadataEntity;
 import com.xavelo.sqs.adapter.out.mysql.spotify.SpotifyArtistMetadataRepository;
 import com.xavelo.sqs.application.domain.Artist;
@@ -16,8 +16,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.DATABASE;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.DATABASE;
 
 @Adapter
 public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort, ResetQuoteHitsPort, ResetQuotePostsPort {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxAdapter.java
@@ -2,8 +2,8 @@ package com.xavelo.sqs.adapter.out.mysql.outbox;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.xavelo.adaptermetrics.Adapter;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.application.domain.Quote;
 import com.xavelo.sqs.application.domain.QuoteEvent;
 import com.xavelo.sqs.application.domain.QuoteEventType;
@@ -15,8 +15,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.DATABASE;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.DATABASE;
 
 @Adapter
 public class QuoteEventOutboxAdapter implements QuoteEventOutboxPort {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxMetrics.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxMetrics.java
@@ -2,13 +2,13 @@ package com.xavelo.sqs.adapter.out.mysql.outbox;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import com.xavelo.adaptermetrics.Adapter;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 
 import java.time.LocalDateTime;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.METRICS;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.METRICS;
 
 /**
  * Publishes Micrometer gauges that expose the state of the quote event outbox.

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/SpotifyAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/SpotifyAdapter.java
@@ -1,6 +1,6 @@
 package com.xavelo.sqs.adapter.out.spotify;
 
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyArtistClient;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyArtistResponse;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifySearchClient;
@@ -8,15 +8,15 @@ import com.xavelo.sqs.adapter.out.spotify.client.SpotifySearchResponse;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyTopTracksClient;
 import com.xavelo.sqs.adapter.out.spotify.client.SpotifyTopTracksResponse;
 import com.xavelo.sqs.application.domain.Artist;
-import com.xavelo.adaptermetrics.Adapter;
+import com.xavelo.common.metrics.Adapter;
 import com.xavelo.sqs.port.out.metadata.GetArtistMetadataPort;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import java.util.Collections;
 import java.util.List;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 public class SpotifyAdapter implements GetArtistMetadataPort {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/client/token/SpotifyAuthService.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/spotify/client/token/SpotifyAuthService.java
@@ -1,14 +1,14 @@
 package com.xavelo.sqs.adapter.out.spotify.client.token;
 
-import com.xavelo.adaptermetrics.Adapter;
-import com.xavelo.adaptermetrics.CountAdapterInvocation;
+import com.xavelo.common.metrics.Adapter;
+import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.configuration.spotify.SpotifyProperties;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import java.util.Base64;
 
-import static com.xavelo.adaptermetrics.AdapterMetrics.Direction.OUT;
-import static com.xavelo.adaptermetrics.AdapterMetrics.Type.HTTP;
+import static com.xavelo.common.metrics.AdapterMetrics.Direction.OUT;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.HTTP;
 
 @Adapter
 public class SpotifyAuthService {

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -11,8 +11,8 @@
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>adapter-metrics</artifactId>
-    <name>adapter-metrics</name>
+    <artifactId>common</artifactId>
+    <name>common</name>
     <description>Reusable annotations and metrics aspect for adapter instrumentation</description>
     <packaging>jar</packaging>
 

--- a/common/src/main/java/com/xavelo/common/metrics/Adapter.java
+++ b/common/src/main/java/com/xavelo/common/metrics/Adapter.java
@@ -1,4 +1,4 @@
-package com.xavelo.adaptermetrics;
+package com.xavelo.common.metrics;
 
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;

--- a/common/src/main/java/com/xavelo/common/metrics/AdapterMetrics.java
+++ b/common/src/main/java/com/xavelo/common/metrics/AdapterMetrics.java
@@ -1,4 +1,4 @@
-package com.xavelo.adaptermetrics;
+package com.xavelo.common.metrics;
 
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;

--- a/common/src/main/java/com/xavelo/common/metrics/AdapterMetricsAspect.java
+++ b/common/src/main/java/com/xavelo/common/metrics/AdapterMetricsAspect.java
@@ -1,4 +1,4 @@
-package com.xavelo.adaptermetrics;
+package com.xavelo.common.metrics;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;

--- a/common/src/main/java/com/xavelo/common/metrics/CountAdapterInvocation.java
+++ b/common/src/main/java/com/xavelo/common/metrics/CountAdapterInvocation.java
@@ -1,4 +1,4 @@
-package com.xavelo.adaptermetrics;
+package com.xavelo.common.metrics;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/common/src/main/java/com/xavelo/common/metrics/autoconfigure/AdapterMetricsAutoConfiguration.java
+++ b/common/src/main/java/com/xavelo/common/metrics/autoconfigure/AdapterMetricsAutoConfiguration.java
@@ -1,6 +1,6 @@
-package com.xavelo.adaptermetrics.autoconfigure;
+package com.xavelo.common.metrics.autoconfigure;
 
-import com.xavelo.adaptermetrics.AdapterMetricsAspect;
+import com.xavelo.common.metrics.AdapterMetricsAspect;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;

--- a/common/src/main/java/com/xavelo/common/metrics/autoconfigure/EnableAdapterMetrics.java
+++ b/common/src/main/java/com/xavelo/common/metrics/autoconfigure/EnableAdapterMetrics.java
@@ -1,4 +1,4 @@
-package com.xavelo.adaptermetrics.autoconfigure;
+package com.xavelo.common.metrics.autoconfigure;
 
 import org.springframework.context.annotation.Import;
 

--- a/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.xavelo.common.metrics.autoconfigure.AdapterMetricsAutoConfiguration

--- a/common/src/test/java/com/xavelo/common/metrics/AdapterMetricsAspectTest.java
+++ b/common/src/test/java/com/xavelo/common/metrics/AdapterMetricsAspectTest.java
@@ -1,4 +1,4 @@
-package com.xavelo.adaptermetrics;
+package com.xavelo.common.metrics;
 
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>adapter-metrics</module>
+        <module>common</module>
         <module>api</module>
         <module>application</module>
     </modules>


### PR DESCRIPTION
## Summary
- rename the adapter-metrics module to common and update parent/application pom references
- move the metrics annotations, aspect, and auto-configuration to the com.xavelo.common.metrics package
- update application adapters to import the new common metrics package

## Testing
- mvn -pl common test

------
https://chatgpt.com/codex/tasks/task_e_68e1290025a883298559bae75b91dc19