### PR TITLE
Refactor adapter metrics to shared module implementation

### DIFF
--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/MysqlAdapter.java
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 
 import static com.xavelo.common.metrics.AdapterMetrics.Direction.OUT;
-import static com.xavelo.common.metrics.AdapterMetrics.Type.MYSQL;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.DATABASE;
 
 @Adapter
 public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuotePort, QuotesCountPort, IncrementPostsPort, IncrementHitsPort, LoadArtistQuoteCountsPort, UpdateQuotePort, LoadTop10QuotesPort, PatchQuotePort, LoadArtistPort, SyncArtistMetadataPort, ResetQuoteHitsPort, ResetQuotePostsPort {
@@ -37,7 +37,7 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     }
 
     @Override
-    @CountAdapterInvocation(name = "store-quote", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "store-quote", direction = OUT, type = DATABASE)
     public Long storeQuote(Quote quote, Artist artistMetadata) {
         QuoteEntity entity = quoteMapper.toEntity(quote);
         if (artistMetadata != null) {
@@ -61,7 +61,7 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     }
 
     @Override
-    @CountAdapterInvocation(name = "sync-artist-metadata", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "sync-artist-metadata", direction = OUT, type = DATABASE)
     public void syncArtistMetadata(String artistName, Artist artistMetadata) {
         if (artistMetadata == null || artistMetadata.id() == null) {
             logger.warn("Cannot sync metadata for artist {} due to missing Spotify id", artistName);
@@ -88,7 +88,7 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     }
 
     @Override
-    @CountAdapterInvocation(name = "store-quotes", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "store-quotes", direction = OUT, type = DATABASE)
     public java.util.List<Long> storeQuotes(List<Quote> quotes) {
         java.util.List<QuoteEntity> entities = quotes.stream()
                 .map(quoteMapper::toEntity)
@@ -98,7 +98,7 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     }
 
     @Override
-    @CountAdapterInvocation(name = "load-quotes", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "load-quotes", direction = OUT, type = DATABASE)
     public java.util.List<Quote> loadQuotes() {
         java.util.List<QuoteEntity> entities = quoteRepository.findAll();
         return entities.stream()
@@ -107,7 +107,7 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     }
 
     @Override
-    @CountAdapterInvocation(name = "load-quote", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "load-quote", direction = OUT, type = DATABASE)
     public Quote loadQuote(Long id) {
         return quoteRepository.findById(id)
                 .map(quoteMapper::toDomain)
@@ -115,7 +115,7 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     }
 
     @Override
-    @CountAdapterInvocation(name = "load-random-quote", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "load-random-quote", direction = OUT, type = DATABASE)
     public Quote loadRandomQuote() {
         QuoteEntity entity = quoteRepository.findRandomQuote();
         if (entity == null) {
@@ -125,43 +125,43 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     }
 
     @Override
-    @CountAdapterInvocation(name = "delete-quote", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "delete-quote", direction = OUT, type = DATABASE)
     public void deleteQuote(Long id) {
         quoteRepository.deleteById(id);
     }
 
     @Override
-    @CountAdapterInvocation(name = "count-quotes", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "count-quotes", direction = OUT, type = DATABASE)
     public Long countQuotes() {
         return quoteRepository.count();
     }
 
     @Override
-    @CountAdapterInvocation(name = "increment-posts", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "increment-posts", direction = OUT, type = DATABASE)
     public void incrementPosts(Long id) {
         quoteRepository.incrementPosts(id);
     }
 
     @Override
-    @CountAdapterInvocation(name = "increment-hits", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "increment-hits", direction = OUT, type = DATABASE)
     public void incrementHits(Long id) {
         quoteRepository.incrementHits(id);
     }
 
     @Override
-    @CountAdapterInvocation(name = "reset-quote-hits", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "reset-quote-hits", direction = OUT, type = DATABASE)
     public void resetQuoteHits() {
         quoteRepository.resetHits();
     }
 
     @Override
-    @CountAdapterInvocation(name = "reset-quote-posts", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "reset-quote-posts", direction = OUT, type = DATABASE)
     public void resetQuotePosts() {
         quoteRepository.resetPosts();
     }
 
     @Override
-    @CountAdapterInvocation(name = "load-artist-quote-counts", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "load-artist-quote-counts", direction = OUT, type = DATABASE)
     public java.util.List<ArtistQuoteCount> loadArtistQuoteCounts() {
         java.util.List<ArtistQuoteCountView> views = quoteRepository.findArtistQuoteCounts();
         return views.stream()
@@ -170,7 +170,7 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     }
 
     @Override
-    @CountAdapterInvocation(name = "update-quote", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "update-quote", direction = OUT, type = DATABASE)
     public void updateQuote(Quote quote) {
         QuoteEntity entity = quoteRepository.findById(quote.id()).orElse(null);
         if (entity != null) {
@@ -184,7 +184,7 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     }
 
     @Override
-    @CountAdapterInvocation(name = "load-top10-quotes", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "load-top10-quotes", direction = OUT, type = DATABASE)
     public List<Quote> loadTop10Quotes() {
         List<QuoteEntity> entities = quoteRepository.findTop10ByOrderByHitsDesc();
         return entities.stream()
@@ -193,7 +193,7 @@ public class MysqlAdapter implements StoreQuotePort, LoadQuotePort, DeleteQuoteP
     }
 
     @Override
-    @CountAdapterInvocation(name = "patch-quote", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "patch-quote", direction = OUT, type = DATABASE)
     public void patchQuote(Long id, Quote quote) {
         QuoteEntity entity = quoteRepository.findById(id).orElse(null);
         if (entity != null) {

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/outbox/QuoteEventOutboxAdapter.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.xavelo.common.metrics.AdapterMetrics.Direction.OUT;
-import static com.xavelo.common.metrics.AdapterMetrics.Type.MYSQL;
+import static com.xavelo.common.metrics.AdapterMetrics.Type.DATABASE;
 
 @Adapter
 public class QuoteEventOutboxAdapter implements QuoteEventOutboxPort {
@@ -31,14 +31,14 @@ public class QuoteEventOutboxAdapter implements QuoteEventOutboxPort {
 
     @Override
     @Transactional
-    @CountAdapterInvocation(name = "record-quote-created-event", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "record-quote-created-event", direction = OUT, type = DATABASE)
     public void recordQuoteCreatedEvent(Quote quote) {
         persistEvent(quote, QuoteEventType.CREATED);
     }
 
     @Override
     @Transactional
-    @CountAdapterInvocation(name = "record-quote-hit-event", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "record-quote-hit-event", direction = OUT, type = DATABASE)
     public void recordQuoteHitEvent(Quote quote) {
         persistEvent(quote, QuoteEventType.HIT);
     }
@@ -55,7 +55,7 @@ public class QuoteEventOutboxAdapter implements QuoteEventOutboxPort {
 
     @Override
     @Transactional
-    @CountAdapterInvocation(name = "fetch-pending-outbox-events", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "fetch-pending-outbox-events", direction = OUT, type = DATABASE)
     public List<QuoteEvent> fetchPendingEvents(int batchSize) {
         List<QuoteEventEntity> entities = repository.findPendingEvents(
                 QuoteEventStatus.PENDING,
@@ -84,7 +84,7 @@ public class QuoteEventOutboxAdapter implements QuoteEventOutboxPort {
 
     @Override
     @Transactional
-    @CountAdapterInvocation(name = "mark-event-published", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "mark-event-published", direction = OUT, type = DATABASE)
     public void markEventPublished(Long id) {
         repository.findById(id).ifPresent(entity -> {
             entity.setStatus(QuoteEventStatus.PUBLISHED);
@@ -94,7 +94,7 @@ public class QuoteEventOutboxAdapter implements QuoteEventOutboxPort {
 
     @Override
     @Transactional
-    @CountAdapterInvocation(name = "mark-event-failed", direction = OUT, type = MYSQL)
+    @CountAdapterInvocation(name = "mark-event-failed", direction = OUT, type = DATABASE)
     public void markEventFailed(Long id, String errorMessage, Duration retryDelay) {
         repository.findById(id).ifPresent(entity -> {
             entity.setStatus(QuoteEventStatus.PENDING);

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -18,6 +18,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
@@ -27,19 +31,15 @@
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>
-            <artifactId>aspectjrt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
+            <artifactId>aspectjweaver</artifactId>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/common/src/main/java/com/xavelo/common/metrics/Adapter.java
+++ b/common/src/main/java/com/xavelo/common/metrics/Adapter.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.TYPE})
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Component

--- a/common/src/main/java/com/xavelo/common/metrics/AdapterMetricsAutoConfiguration.java
+++ b/common/src/main/java/com/xavelo/common/metrics/AdapterMetricsAutoConfiguration.java
@@ -1,10 +1,12 @@
-package com.xavelo.common.metrics.autoconfigure;
+package com.xavelo.common.metrics;
 
-import com.xavelo.common.metrics.AdapterMetricsAspect;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
+/**
+ * Auto-configuration that exposes the {@link AdapterMetricsAspect} bean.
+ */
 @AutoConfiguration
 public class AdapterMetricsAutoConfiguration {
 

--- a/common/src/main/java/com/xavelo/common/metrics/CountAdapterInvocation.java
+++ b/common/src/main/java/com/xavelo/common/metrics/CountAdapterInvocation.java
@@ -1,14 +1,18 @@
 package com.xavelo.common.metrics;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotate adapter methods to automatically record invocation metrics.
+ */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Documented
 public @interface CountAdapterInvocation {
-
     String name();
     AdapterMetrics.Direction direction();
     AdapterMetrics.Type type();

--- a/common/src/main/java/com/xavelo/common/metrics/EnableAdapterMetrics.java
+++ b/common/src/main/java/com/xavelo/common/metrics/EnableAdapterMetrics.java
@@ -1,16 +1,20 @@
-package com.xavelo.common.metrics.autoconfigure;
-
-import org.springframework.context.annotation.Import;
+package com.xavelo.common.metrics;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
 
+/**
+ * Enables adapter metrics instrumentation.
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Import(AdapterMetricsAutoConfiguration.class)
+@EnableAspectJAutoProxy(proxyTargetClass = true)
 public @interface EnableAdapterMetrics {
 }

--- a/common/src/main/java/com/xavelo/common/metrics/package-info.java
+++ b/common/src/main/java/com/xavelo/common/metrics/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Provides annotations and support for instrumenting adapter invocations.
+ * <p>
+ * Add {@link com.xavelo.common.metrics.EnableAdapterMetrics @EnableAdapterMetrics}
+ * to a Spring configuration class and annotate adapter methods with
+ * {@link com.xavelo.common.metrics.CountAdapterInvocation @CountAdapterInvocation}
+ * to automatically emit counters and timers tagged with the adapter name, type,
+ * direction, and invocation result.
+ */
+@NonNullApi
+package com.xavelo.common.metrics;
+
+import org.springframework.lang.NonNullApi;

--- a/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,1 @@
-com.xavelo.common.metrics.autoconfigure.AdapterMetricsAutoConfiguration
+com.xavelo.common.metrics.AdapterMetricsAutoConfiguration

--- a/common/src/test/java/com/xavelo/common/metrics/AdapterMetricsAspectTest.java
+++ b/common/src/test/java/com/xavelo/common/metrics/AdapterMetricsAspectTest.java
@@ -1,81 +1,100 @@
 package com.xavelo.common.metrics;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.aspectj.lang.ProceedingJoinPoint;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
-
-@ExtendWith(MockitoExtension.class)
 class AdapterMetricsAspectTest {
 
-    @Mock
-    private ProceedingJoinPoint joinPoint;
-
-    private AdapterMetricsAspect aspect;
-
-    private SimpleMeterRegistry meterRegistry;
-
-    private CountAdapterInvocation annotation;
+    private SimpleMeterRegistry registry;
 
     @BeforeEach
     void setUp() {
-        aspect = new AdapterMetricsAspect();
-        meterRegistry = new SimpleMeterRegistry();
-        Metrics.globalRegistry.add(meterRegistry);
-        annotation = new CountAdapterInvocation() {
-            @Override
-            public String name() {
-                return "test-adapter";
-            }
-
-            @Override
-            public AdapterMetrics.Direction direction() {
-                return AdapterMetrics.Direction.OUT;
-            }
-
-            @Override
-            public AdapterMetrics.Type type() {
-                return AdapterMetrics.Type.HTTP;
-            }
-
-            @Override
-            public Class<? extends java.lang.annotation.Annotation> annotationType() {
-                return CountAdapterInvocation.class;
-            }
-        };
+        registry = new SimpleMeterRegistry();
+        Metrics.globalRegistry.add(registry);
     }
 
     @AfterEach
     void tearDown() {
-        Metrics.globalRegistry.remove(meterRegistry);
-        meterRegistry.close();
+        Metrics.globalRegistry.remove(registry);
+        registry.close();
     }
 
     @Test
-    void countAdapterInvocation_recordsErrorOnThrowable() throws Throwable {
-        Error error = new Error("boom");
-        when(joinPoint.proceed()).thenThrow(error);
+    void successfulInvocationIncrementsSuccessCounterAndRecordsDuration() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            context.register(TestConfiguration.class);
+            context.refresh();
 
-        assertThatThrownBy(() -> aspect.countAdapterInvocation(joinPoint, annotation))
-                .isSameAs(error);
+            TestAdapter adapter = context.getBean(TestAdapter.class);
+            adapter.invoke();
 
-        double errorCount = meterRegistry.get("adapter.invocation")
-                .tag("name", "test-adapter")
-                .tag("type", "http")
-                .tag("direction", "out")
-                .tag("result", "error")
-                .counter()
-                .count();
+            var successCounter = registry
+                    .find(AdapterMetrics.METRIC_ADAPTER_INVOCATIONS)
+                    .tags("adapter", "test-adapter", "type", "HTTP", "direction", "OUT", "result", "SUCCESS")
+                    .counter();
+            assertThat(successCounter).isNotNull();
+            assertThat(successCounter.count()).isEqualTo(1.0d);
 
-        assertThat(errorCount).isEqualTo(1.0d);
+            Timer timer = registry
+                    .find(AdapterMetrics.METRIC_ADAPTER_DURATION)
+                    .tags("adapter", "test-adapter", "type", "HTTP", "direction", "OUT")
+                    .timer();
+            assertThat(timer).isNotNull();
+            assertThat(timer.count()).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    void failedInvocationIncrementsErrorCounterAndPropagatesException() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            context.register(TestConfiguration.class);
+            context.refresh();
+
+            TestAdapter adapter = context.getBean(TestAdapter.class);
+
+            assertThatThrownBy(adapter::fail)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("boom");
+
+            var errorCounter = registry
+                    .find(AdapterMetrics.METRIC_ADAPTER_INVOCATIONS)
+                    .tags("adapter", "test-adapter", "type", "HTTP", "direction", "OUT", "result", "ERROR")
+                    .counter();
+            assertThat(errorCounter).isNotNull();
+            assertThat(errorCounter.count()).isEqualTo(1.0d);
+        }
+    }
+
+    @Configuration
+    @EnableAdapterMetrics
+    static class TestConfiguration {
+
+        @Bean
+        TestAdapter testAdapter() {
+            return new TestAdapter();
+        }
+    }
+
+    static class TestAdapter {
+
+        @CountAdapterInvocation(name = "test-adapter", type = AdapterMetrics.Type.HTTP, direction = AdapterMetrics.Direction.OUT)
+        public String invoke() {
+            return "ok";
+        }
+
+        @CountAdapterInvocation(name = "test-adapter", type = AdapterMetrics.Type.HTTP, direction = AdapterMetrics.Direction.OUT)
+        public String fail() {
+            throw new IllegalStateException("boom");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the common metrics helper, annotations, and auto-configuration with the implementation from the template app
- update the common module dependencies, package metadata, and tests to match the shared module
- refactor the MySQL adapters to use the shared AdapterMetrics.Type.DATABASE enum

## Testing
- ./mvnw -pl common test *(fails: network is unreachable while the Maven wrapper downloads dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e16ea460e88329afbac46fc52a4b39