### PR TITLE
Use UUID identifiers for quotes

### DIFF
--- a/api/src/main/resources/openapi/admin-api.yaml
+++ b/api/src/main/resources/openapi/admin-api.yaml
@@ -27,8 +27,8 @@ paths:
           content:
             application/json:
               schema:
-                type: integer
-                format: int64
+                type: string
+                format: uuid
   /admin/quotes:
     post:
       tags:
@@ -51,16 +51,16 @@ paths:
               schema:
                 type: array
                 items:
-                  type: integer
-                  format: int64
+                  type: string
+                  format: uuid
   /admin/quote/{id}:
     parameters:
       - name: id
         in: path
         required: true
         schema:
-          type: integer
-          format: int64
+          type: string
+          format: uuid
     delete:
       tags:
         - Admin

--- a/api/src/main/resources/openapi/components/schemas.yaml
+++ b/api/src/main/resources/openapi/components/schemas.yaml
@@ -4,8 +4,8 @@ components:
       type: object
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
+          format: uuid
           description: Identifier of the quote
         quote:
           type: string

--- a/api/src/main/resources/openapi/quote-api.yaml
+++ b/api/src/main/resources/openapi/quote-api.yaml
@@ -64,8 +64,8 @@ paths:
           in: path
           required: true
           schema:
-            type: integer
-            format: int64
+            type: string
+            format: uuid
       responses:
         '200':
           description: Quote found

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -55,30 +55,30 @@ public class AdminController implements AdminApi {
 
     @Override
     @CountAdapterInvocation(name = "create-quote", direction = IN, type = HTTP)
-    public ResponseEntity<Long> createQuote(@Valid @RequestBody QuoteDto quoteDto) {
+    public ResponseEntity<String> createQuote(@Valid @RequestBody QuoteDto quoteDto) {
         Quote quote = quoteMapper.toDomain(quoteDto);
-        Long id = storeQuoteUseCase.storeQuote(quote);
+        String id = storeQuoteUseCase.storeQuote(quote);
         return ResponseEntity.ok(id);
     }
 
     @Override
     @CountAdapterInvocation(name = "create-quotes", direction = IN, type = HTTP)
-    public ResponseEntity<List<Long>> createQuotes(@Valid @RequestBody List<@Valid QuoteDto> quoteDtos) {
+    public ResponseEntity<List<String>> createQuotes(@Valid @RequestBody List<@Valid QuoteDto> quoteDtos) {
         List<Quote> quotes = quoteMapper.toDomain(quoteDtos);
-        List<Long> ids = storeQuoteUseCase.storeQuotes(quotes);
+        List<String> ids = storeQuoteUseCase.storeQuotes(quotes);
         return ResponseEntity.ok(ids);
     }
 
     @Override
     @CountAdapterInvocation(name = "delete-quote", direction = IN, type = HTTP)
-    public ResponseEntity<Void> deleteQuote(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteQuote(@PathVariable String id) {
         adminService.deleteQuote(id);
         return ResponseEntity.noContent().build();
     }
 
     @Override
     @CountAdapterInvocation(name = "update-quote", direction = IN, type = HTTP)
-    public ResponseEntity<Void> updateQuote(@PathVariable Long id, @Valid @RequestBody QuoteDto quoteDto) {
+    public ResponseEntity<Void> updateQuote(@PathVariable String id, @Valid @RequestBody QuoteDto quoteDto) {
         Quote quote = quoteMapper.toDomain(quoteDto);
         if (containsRestrictedFields(quote)) {
             return ResponseEntity.badRequest().build();
@@ -93,7 +93,7 @@ public class AdminController implements AdminApi {
 
     @Override
     @CountAdapterInvocation(name = "patch-quote", direction = IN, type = HTTP)
-    public ResponseEntity<Void> patchQuote(@PathVariable Long id, @Valid @RequestBody QuoteDto quoteDto) {
+    public ResponseEntity<Void> patchQuote(@PathVariable String id, @Valid @RequestBody QuoteDto quoteDto) {
         Quote quote = quoteMapper.toDomain(quoteDto);
         if (containsRestrictedFields(quote)) {
             return ResponseEntity.badRequest().build();

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
@@ -72,7 +72,7 @@ public class QuoteController implements QuoteApi {
 
     @Override
     @CountAdapterInvocation(name = "get-quote", direction = IN, type = HTTP)
-    public ResponseEntity<QuoteDto> getQuote(@PathVariable("id") Long id) {
+    public ResponseEntity<QuoteDto> getQuote(@PathVariable("id") String id) {
         Quote quote = getQuoteUseCase.getQuote(id);
         return quote != null
                 ? ResponseEntity.ok(quoteMapper.toDto(quote))

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
@@ -24,7 +24,7 @@ public class MicrometerMetricsAdapter implements MetricsPort {
     private final MeterRegistry meterRegistry;
     private final Counter totalHitsCounter;
     private final Counter storedQuotesCounter;
-    private final ConcurrentMap<Long, Counter> quoteHitsCounters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Counter> quoteHitsCounters = new ConcurrentHashMap<>();
 
     public MicrometerMetricsAdapter(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
@@ -50,7 +50,7 @@ public class MicrometerMetricsAdapter implements MetricsPort {
 
     @Override
     @CountAdapterInvocation(name = "increment-quote-hits", direction = OUT, type = METRICS)
-    public void incrementQuoteHits(Long quoteId) {
+    public void incrementQuoteHits(String quoteId) {
         if (quoteId == null) {
             return;
         }
@@ -60,10 +60,10 @@ public class MicrometerMetricsAdapter implements MetricsPort {
                 .increment();
     }
 
-    private Counter createQuoteHitsCounter(Long quoteId) {
+    private Counter createQuoteHitsCounter(String quoteId) {
         return Counter.builder(QUOTE_HITS_METRIC_NAME)
                 .description("Number of times a specific quote was requested")
-                .tag("quote_id", quoteId.toString())
+                .tag("quote_id", quoteId)
                 .register(meterRegistry);
     }
 }

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteEntity.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteEntity.java
@@ -1,8 +1,6 @@
 package com.xavelo.sqs.adapter.out.mysql;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Column;
@@ -12,8 +10,8 @@ import jakarta.persistence.Column;
 public class QuoteEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(length = 36, columnDefinition = "char(36)")
+    private String id;
 
     private String quote;
     private String song;
@@ -28,11 +26,11 @@ public class QuoteEntity {
     @Column(name = "spotify_artist_id")
     private String spotifyArtistId;
 
-    public Long getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepository.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import com.xavelo.sqs.adapter.out.mysql.ArtistQuoteCountView;
 
-public interface QuoteRepository extends JpaRepository<QuoteEntity, Long> {
+public interface QuoteRepository extends JpaRepository<QuoteEntity, String> {
 
     /**
      * Retrieve a single random quote entity.
@@ -20,12 +20,12 @@ public interface QuoteRepository extends JpaRepository<QuoteEntity, Long> {
     @Transactional
     @Modifying
     @Query("update QuoteEntity q set q.posts = q.posts + 1 where q.id = :id")
-    void incrementPosts(@Param("id") Long id);
+    void incrementPosts(@Param("id") String id);
 
     @Transactional
     @Modifying
     @Query("update QuoteEntity q set q.hits = q.hits + 1 where q.id = :id")
-    void incrementHits(@Param("id") Long id);
+    void incrementHits(@Param("id") String id);
 
     @Transactional
     @Modifying

--- a/application/src/main/java/com/xavelo/sqs/application/domain/Quote.java
+++ b/application/src/main/java/com/xavelo/sqs/application/domain/Quote.java
@@ -1,7 +1,7 @@
 package com.xavelo.sqs.application.domain;
 
 public record Quote(
-        Long id,
+        String id,
         String quote,
         String song,
         String album,

--- a/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
@@ -45,7 +45,7 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
         StringBuilder sqlBuilder = new StringBuilder();
         for (Quote quote : quotes) {
             sqlBuilder.append(String.format(
-                    "INSERT INTO quotes (id, quote, song, album, album_year, artist, hits, posts) VALUES (%d, '%s', '%s', '%s', %d, '%s', %d, %d);\n",
+                    "INSERT INTO quotes (id, quote, song, album, album_year, artist, hits, posts) VALUES ('%s', '%s', '%s', '%s', %d, '%s', %d, %d);\n",
                     quote.id(),
                     quote.quote().replace("'", "''"),
                     quote.song().replace("'", "''"),
@@ -60,7 +60,7 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
     }
 
     @Override
-    public void deleteQuote(Long id) {
+    public void deleteQuote(String id) {
         deleteQuotePort.deleteQuote(id);
     }
 

--- a/application/src/main/java/com/xavelo/sqs/application/service/QuoteHelper.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/QuoteHelper.java
@@ -33,7 +33,7 @@ public final class QuoteHelper {
     /**
      * Returns a copy of the given quote with the supplied id.
      */
-    public static Quote withId(Quote quote, Long id) {
+    public static Quote withId(Quote quote, String id) {
         if (quote == null) {
             return null;
         }
@@ -53,7 +53,7 @@ public final class QuoteHelper {
     /**
      * Returns a copy of the given quote with the supplied id and spotify artist id
      */
-    public static Quote withSpotifyArtistId(Quote quote, Long id, String spotifyArtistId) {
+    public static Quote withSpotifyArtistId(Quote quote, String id, String spotifyArtistId) {
         if (quote == null) {
             return null;
         }

--- a/application/src/main/java/com/xavelo/sqs/port/in/DeleteQuoteUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/DeleteQuoteUseCase.java
@@ -1,5 +1,5 @@
 package com.xavelo.sqs.port.in;
 
 public interface DeleteQuoteUseCase {
-    void deleteQuote(Long id);
+    void deleteQuote(String id);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/in/GetQuoteUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/GetQuoteUseCase.java
@@ -3,5 +3,5 @@ package com.xavelo.sqs.port.in;
 import com.xavelo.sqs.application.domain.Quote;
 
 public interface GetQuoteUseCase {
-    Quote getQuote(Long id);
+    Quote getQuote(String id);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/in/PatchQuoteUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/PatchQuoteUseCase.java
@@ -3,5 +3,5 @@ package com.xavelo.sqs.port.in;
 import com.xavelo.sqs.application.domain.Quote;
 
 public interface PatchQuoteUseCase {
-    void patchQuote(Long id, Quote quote);
+    void patchQuote(String id, Quote quote);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/in/StoreQuoteUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/StoreQuoteUseCase.java
@@ -5,6 +5,6 @@ import com.xavelo.sqs.application.domain.Quote;
 import java.util.List;
 
 public interface StoreQuoteUseCase {
-    Long storeQuote(Quote quote);
-    List<Long> storeQuotes(List<Quote> quotes);
+    String storeQuote(Quote quote);
+    List<String> storeQuotes(List<Quote> quotes);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/DeleteQuotePort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/DeleteQuotePort.java
@@ -1,5 +1,5 @@
 package com.xavelo.sqs.port.out;
 
 public interface DeleteQuotePort {
-    void deleteQuote(Long id);
+    void deleteQuote(String id);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/IncrementHitsPort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/IncrementHitsPort.java
@@ -1,5 +1,5 @@
 package com.xavelo.sqs.port.out;
 
 public interface IncrementHitsPort {
-    void incrementHits(Long id);
+    void incrementHits(String id);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/IncrementPostsPort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/IncrementPostsPort.java
@@ -1,5 +1,5 @@
 package com.xavelo.sqs.port.out;
 
 public interface IncrementPostsPort {
-    void incrementPosts(Long id);
+    void incrementPosts(String id);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/LoadQuotePort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/LoadQuotePort.java
@@ -6,7 +6,7 @@ import java.util.List;
 public interface LoadQuotePort {
     List<Quote> loadQuotes();
 
-    Quote loadQuote(Long id);
+    Quote loadQuote(String id);
 
     /**
      * Retrieve a random quote from the storage.

--- a/application/src/main/java/com/xavelo/sqs/port/out/MetricsPort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/MetricsPort.java
@@ -19,5 +19,5 @@ public interface MetricsPort {
      *
      * @param quoteId the identifier of the quote that was served
      */
-    void incrementQuoteHits(Long quoteId);
+    void incrementQuoteHits(String quoteId);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/PatchQuotePort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/PatchQuotePort.java
@@ -3,5 +3,5 @@ package com.xavelo.sqs.port.out;
 import com.xavelo.sqs.application.domain.Quote;
 
 public interface PatchQuotePort {
-    void patchQuote(Long id, Quote quote);
+    void patchQuote(String id, Quote quote);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/StoreQuotePort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/StoreQuotePort.java
@@ -6,6 +6,6 @@ import com.xavelo.sqs.application.domain.Quote;
 import java.util.List;
 
 public interface StoreQuotePort {
-    Long storeQuote(Quote quote, Artist artistMetadata);
-    List<Long> storeQuotes(List<Quote> quotes);
+    String storeQuote(Quote quote, Artist artistMetadata);
+    List<String> storeQuotes(List<Quote> quotes);
 }

--- a/application/src/main/resources/db/migration/V1__baseline.sql
+++ b/application/src/main/resources/db/migration/V1__baseline.sql
@@ -1,5 +1,5 @@
 CREATE TABLE quotes (
-    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    id CHAR(36) PRIMARY KEY,
     quote VARCHAR(1000),
     song VARCHAR(255),
     album VARCHAR(255),

--- a/application/src/main/resources/db/migration/V2__quote_ids_as_uuid.sql
+++ b/application/src/main/resources/db/migration/V2__quote_ids_as_uuid.sql
@@ -1,0 +1,21 @@
+ALTER TABLE quotes
+    ADD COLUMN new_id CHAR(36) NULL AFTER id;
+
+UPDATE quotes
+SET new_id = UUID()
+WHERE new_id IS NULL;
+
+ALTER TABLE quotes
+    MODIFY COLUMN new_id CHAR(36) NOT NULL;
+
+ALTER TABLE quotes
+    DROP PRIMARY KEY;
+
+ALTER TABLE quotes
+    DROP COLUMN id;
+
+ALTER TABLE quotes
+    CHANGE COLUMN new_id id CHAR(36) NOT NULL;
+
+ALTER TABLE quotes
+    ADD PRIMARY KEY (id);

--- a/application/src/test/java/com/xavelo/sqs/adapter/in/http/quote/QuoteControllerTest.java
+++ b/application/src/test/java/com/xavelo/sqs/adapter/in/http/quote/QuoteControllerTest.java
@@ -20,6 +20,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(QuoteController.class)
 class QuoteControllerTest {
 
+    private static final String QUOTE_ID = "55555555-5555-5555-5555-555555555555";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -38,9 +40,9 @@ class QuoteControllerTest {
 
     @Test
     void getQuotes() throws Exception {
-        List<Quote> quotes = List.of(new Quote(1L, "q", "s", "a", 1999, "art", 0, 0, null));
+        List<Quote> quotes = List.of(new Quote(QUOTE_ID, "q", "s", "a", 1999, "art", 0, 0, null));
         List<QuoteDto> dtos = List.of(new QuoteDto()
-                .id(1L)
+                .id(QUOTE_ID)
                 .quote("q")
                 .song("s")
                 .album("a")
@@ -68,9 +70,9 @@ class QuoteControllerTest {
 
     @Test
     void getRandomQuoteFound() throws Exception {
-        Quote quote = new Quote(1L, "q", "s", "a", 1999, "art", 0, 0, null);
+        Quote quote = new Quote(QUOTE_ID, "q", "s", "a", 1999, "art", 0, 0, null);
         QuoteDto dto = new QuoteDto()
-                .id(1L)
+                .id(QUOTE_ID)
                 .quote("q")
                 .song("s")
                 .album("a")
@@ -89,9 +91,9 @@ class QuoteControllerTest {
 
     @Test
     void getQuoteFound() throws Exception {
-        Quote quote = new Quote(1L, "q", "s", "a", 1999, "art", 0, 0, null);
+        Quote quote = new Quote(QUOTE_ID, "q", "s", "a", 1999, "art", 0, 0, null);
         QuoteDto dto = new QuoteDto()
-                .id(1L)
+                .id(QUOTE_ID)
                 .quote("q")
                 .song("s")
                 .album("a")
@@ -100,31 +102,31 @@ class QuoteControllerTest {
                 .posts(0)
                 .hits(0)
                 .spotifyArtistId(null);
-        when(getQuoteUseCase.getQuote(1L)).thenReturn(quote);
+        when(getQuoteUseCase.getQuote(QUOTE_ID)).thenReturn(quote);
         when(quoteMapper.toDto(quote)).thenReturn(dto);
 
-        mockMvc.perform(get("/api/quote/1"))
+        mockMvc.perform(get("/api/quote/" + QUOTE_ID))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(dto)));
     }
 
     @Test
     void getQuoteNotFound() throws Exception {
-        when(getQuoteUseCase.getQuote(2L)).thenReturn(null);
+        when(getQuoteUseCase.getQuote("non-existent-id")).thenReturn(null);
 
-        mockMvc.perform(get("/api/quote/2"))
+        mockMvc.perform(get("/api/quote/non-existent-id"))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void getTop10Quotes() throws Exception {
         List<Quote> quotes = List.of(
-                new Quote(1L, "q1", "s1", "a1", 2000, "art1", 100, 10, null),
-                new Quote(2L, "q2", "s2", "a2", 2001, "art2", 90, 9, null)
+                new Quote("66666666-6666-6666-6666-666666666666", "q1", "s1", "a1", 2000, "art1", 100, 10, null),
+                new Quote("77777777-7777-7777-7777-777777777777", "q2", "s2", "a2", 2001, "art2", 90, 9, null)
         );
         List<QuoteDto> dtos = List.of(
                 new QuoteDto()
-                        .id(1L)
+                        .id("66666666-6666-6666-6666-666666666666")
                         .quote("q1")
                         .song("s1")
                         .album("a1")
@@ -134,7 +136,7 @@ class QuoteControllerTest {
                         .hits(10)
                         .spotifyArtistId(null),
                 new QuoteDto()
-                        .id(2L)
+                        .id("77777777-7777-7777-7777-777777777777")
                         .quote("q2")
                         .song("s2")
                         .album("a2")

--- a/application/src/test/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepositoryTest.java
+++ b/application/src/test/java/com/xavelo/sqs/adapter/out/mysql/QuoteRepositoryTest.java
@@ -9,6 +9,7 @@ import jakarta.persistence.EntityManager;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,6 +26,7 @@ class QuoteRepositoryTest {
 
     private QuoteEntity createEntity(String quote, String artist, String spotifyArtistId) {
         QuoteEntity e = new QuoteEntity();
+        e.setId(UUID.randomUUID().toString());
         e.setQuote(quote);
         e.setSong("song");
         e.setAlbum("album");

--- a/application/src/test/java/com/xavelo/sqs/application/service/QuoteEventRelayWorkerTest.java
+++ b/application/src/test/java/com/xavelo/sqs/application/service/QuoteEventRelayWorkerTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class QuoteEventRelayWorkerTest {
 
+    private static final String QUOTE_ID = "33333333-3333-3333-3333-333333333333";
+
     @Mock
     private QuoteEventOutboxPort quoteEventOutboxPort;
 
@@ -42,7 +44,7 @@ class QuoteEventRelayWorkerTest {
 
     @Test
     void relayOutbox_publishesCreatedEvent() {
-        Quote quote = new Quote(1L, "quote", "song", "album", 1990, "artist", 0, 0, null);
+        Quote quote = new Quote(QUOTE_ID, "quote", "song", "album", 1990, "artist", 0, 0, null);
         QuoteEvent event = new QuoteEvent(1L, QuoteEventType.CREATED, quote, 1);
         when(quoteEventOutboxPort.fetchPendingEvents(10)).thenReturn(List.of(event));
 
@@ -54,7 +56,7 @@ class QuoteEventRelayWorkerTest {
 
     @Test
     void relayOutbox_handlesPublishFailure() {
-        Quote quote = new Quote(1L, "quote", "song", "album", 1990, "artist", 0, 0, null);
+        Quote quote = new Quote(QUOTE_ID, "quote", "song", "album", 1990, "artist", 0, 0, null);
         QuoteEvent event = new QuoteEvent(1L, QuoteEventType.CREATED, quote, 1);
         when(quoteEventOutboxPort.fetchPendingEvents(10)).thenReturn(List.of(event));
         doThrow(new RuntimeException("boom")).when(publishQuoteCreatedPort).publishQuoteCreated(quote);
@@ -66,7 +68,7 @@ class QuoteEventRelayWorkerTest {
 
     @Test
     void relayOutbox_publishesHitEvent() {
-        Quote quote = new Quote(1L, "quote", "song", "album", 1990, "artist", 0, 1, null);
+        Quote quote = new Quote(QUOTE_ID, "quote", "song", "album", 1990, "artist", 0, 1, null);
         QuoteEvent event = new QuoteEvent(2L, QuoteEventType.HIT, quote, 1);
         when(quoteEventOutboxPort.fetchPendingEvents(10)).thenReturn(List.of(event));
 

--- a/application/src/test/java/com/xavelo/sqs/application/service/QuoteMetricsServiceTest.java
+++ b/application/src/test/java/com/xavelo/sqs/application/service/QuoteMetricsServiceTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 @ExtendWith(MockitoExtension.class)
 class QuoteMetricsServiceTest {
 
+    private static final String QUOTE_ID = "44444444-4444-4444-4444-444444444444";
+
     @Mock
     private MetricsPort metricsPort;
 
@@ -27,7 +29,7 @@ class QuoteMetricsServiceTest {
 
     @BeforeEach
     void setUp() {
-        quote = new Quote(1L, "quote", "song", "album", 1990, "artist", 0, 1, null);
+        quote = new Quote(QUOTE_ID, "quote", "song", "album", 1990, "artist", 0, 1, null);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- store quotes using UUID-based identifiers end-to-end and generate IDs in the MySQL adapter
- update application services, controllers, ports, and metrics to accept string quote IDs and adjust tests accordingly
- align Flyway migrations and OpenAPI specs with 36-character UUID identifiers

## Testing
- `./mvnw -pl application test` *(fails: Maven wrapper could not download distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e23f2fcb94832998675b74a5b59753