### PR TITLE
Fix QuoteController UUID path parameter

### DIFF
--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 import static com.xavelo.common.metrics.AdapterMetrics.Direction.IN;
 import static com.xavelo.common.metrics.AdapterMetrics.Type.HTTP;
@@ -72,8 +73,8 @@ public class QuoteController implements QuoteApi {
 
     @Override
     @CountAdapterInvocation(name = "get-quote", direction = IN, type = HTTP)
-    public ResponseEntity<QuoteDto> getQuote(@PathVariable("id") String id) {
-        Quote quote = getQuoteUseCase.getQuote(id);
+    public ResponseEntity<QuoteDto> getQuote(@PathVariable("id") UUID id) {
+        Quote quote = getQuoteUseCase.getQuote(id.toString());
         return quote != null
                 ? ResponseEntity.ok(quoteMapper.toDto(quote))
                 : ResponseEntity.notFound().build();

--- a/application/src/test/java/com/xavelo/sqs/adapter/in/http/quote/QuoteControllerTest.java
+++ b/application/src/test/java/com/xavelo/sqs/adapter/in/http/quote/QuoteControllerTest.java
@@ -21,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class QuoteControllerTest {
 
     private static final String QUOTE_ID = "55555555-5555-5555-5555-555555555555";
+    private static final String MISSING_QUOTE_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
     @Autowired
     private MockMvc mockMvc;
@@ -112,9 +113,9 @@ class QuoteControllerTest {
 
     @Test
     void getQuoteNotFound() throws Exception {
-        when(getQuoteUseCase.getQuote("non-existent-id")).thenReturn(null);
+        when(getQuoteUseCase.getQuote(MISSING_QUOTE_ID)).thenReturn(null);
 
-        mockMvc.perform(get("/api/quote/non-existent-id"))
+        mockMvc.perform(get("/api/quote/" + MISSING_QUOTE_ID))
                 .andExpect(status().isNotFound());
     }
 


### PR DESCRIPTION
## Summary
- update QuoteController to accept a UUID path variable to satisfy the QuoteApi contract
- align the controller test with the UUID requirement when exercising the missing quote scenario

## Testing
- `./mvnw -pl application test` *(fails: Network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e2446baff483298e12c1d09d5bbc5e