### PR TITLE
Refactor quote ID handling to use UUIDs

### DIFF
--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static com.xavelo.common.metrics.AdapterMetrics.Direction.IN;
 import static com.xavelo.common.metrics.AdapterMetrics.Type.HTTP;
@@ -63,26 +62,23 @@ public class AdminController implements AdminApi {
     @CountAdapterInvocation(name = "create-quote", direction = IN, type = HTTP)
     public ResponseEntity<UUID> createQuote(@Valid @RequestBody QuoteDto quoteDto) {
         Quote quote = quoteMapper.toDomain(quoteDto);
-        String id = storeQuoteUseCase.storeQuote(quote);
+        UUID id = storeQuoteUseCase.storeQuote(quote);
         logger.debug("returning id {}", id);
-        return ResponseEntity.ok(UUID.fromString(id));
+        return ResponseEntity.ok(id);
     }
 
     @Override
     @CountAdapterInvocation(name = "create-quotes", direction = IN, type = HTTP)
     public ResponseEntity<List<UUID>> createQuotes(@Valid @RequestBody List<@Valid QuoteDto> quoteDtos) {
         List<Quote> quotes = quoteMapper.toDomain(quoteDtos);
-        List<String> ids = storeQuoteUseCase.storeQuotes(quotes);
-        List<UUID> uuids = ids.stream()
-                .map(UUID::fromString)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(uuids);
+        List<UUID> ids = storeQuoteUseCase.storeQuotes(quotes);
+        return ResponseEntity.ok(ids);
     }
 
     @Override
     @CountAdapterInvocation(name = "delete-quote", direction = IN, type = HTTP)
     public ResponseEntity<Void> deleteQuote(@PathVariable UUID id) {
-        adminService.deleteQuote(id.toString());
+        adminService.deleteQuote(id);
         return ResponseEntity.noContent().build();
     }
 
@@ -93,7 +89,7 @@ public class AdminController implements AdminApi {
         if (containsRestrictedFields(quote)) {
             return ResponseEntity.badRequest().build();
         }
-        updateQuoteUseCase.updateQuote(QuoteHelper.withId(quote, id.toString()));
+        updateQuoteUseCase.updateQuote(QuoteHelper.withId(quote, id));
         return ResponseEntity.noContent().build();
     }
 
@@ -108,7 +104,7 @@ public class AdminController implements AdminApi {
         if (containsRestrictedFields(quote)) {
             return ResponseEntity.badRequest().build();
         }
-        patchQuoteUseCase.patchQuote(id.toString(), quote);
+        patchQuoteUseCase.patchQuote(id, quote);
         return ResponseEntity.noContent().build();
     }
 

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/quote/QuoteController.java
@@ -74,7 +74,7 @@ public class QuoteController implements QuoteApi {
     @Override
     @CountAdapterInvocation(name = "get-quote", direction = IN, type = HTTP)
     public ResponseEntity<QuoteDto> getQuote(@PathVariable("id") UUID id) {
-        Quote quote = getQuoteUseCase.getQuote(id.toString());
+        Quote quote = getQuoteUseCase.getQuote(id);
         return quote != null
                 ? ResponseEntity.ok(quoteMapper.toDto(quote))
                 : ResponseEntity.notFound().build();

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/metrics/MicrometerMetricsAdapter.java
@@ -5,6 +5,7 @@ import com.xavelo.common.metrics.CountAdapterInvocation;
 import com.xavelo.sqs.port.out.MetricsPort;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -24,7 +25,7 @@ public class MicrometerMetricsAdapter implements MetricsPort {
     private final MeterRegistry meterRegistry;
     private final Counter totalHitsCounter;
     private final Counter storedQuotesCounter;
-    private final ConcurrentMap<String, Counter> quoteHitsCounters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<UUID, Counter> quoteHitsCounters = new ConcurrentHashMap<>();
 
     public MicrometerMetricsAdapter(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
@@ -50,7 +51,7 @@ public class MicrometerMetricsAdapter implements MetricsPort {
 
     @Override
     @CountAdapterInvocation(name = "increment-quote-hits", direction = OUT, type = METRICS)
-    public void incrementQuoteHits(String quoteId) {
+    public void incrementQuoteHits(UUID quoteId) {
         if (quoteId == null) {
             return;
         }
@@ -60,10 +61,10 @@ public class MicrometerMetricsAdapter implements MetricsPort {
                 .increment();
     }
 
-    private Counter createQuoteHitsCounter(String quoteId) {
+    private Counter createQuoteHitsCounter(UUID quoteId) {
         return Counter.builder(QUOTE_HITS_METRIC_NAME)
                 .description("Number of times a specific quote was requested")
-                .tag("quote_id", quoteId)
+                .tag("quote_id", quoteId.toString())
                 .register(meterRegistry);
     }
 }

--- a/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteMapper.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/out/mysql/QuoteMapper.java
@@ -1,16 +1,19 @@
 package com.xavelo.sqs.adapter.out.mysql;
 
 import com.xavelo.sqs.application.domain.Quote;
-import com.xavelo.sqs.adapter.out.mysql.QuoteEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.UUID;
 
 @Mapper(componentModel = "spring")
 public interface QuoteMapper {
     @Mapping(target = "posts", constant = "0")
     @Mapping(target = "hits", constant = "0")
     @Mapping(target = "spotifyArtistId", source = "spotifyArtistId")
+    @Mapping(target = "id", expression = "java(quote.id() != null ? quote.id().toString() : null)")
     QuoteEntity toEntity(Quote quote);
 
+    @Mapping(target = "id", expression = "java(entity.getId() != null ? UUID.fromString(entity.getId()) : null)")
     Quote toDomain(QuoteEntity entity);
 }

--- a/application/src/main/java/com/xavelo/sqs/application/domain/Quote.java
+++ b/application/src/main/java/com/xavelo/sqs/application/domain/Quote.java
@@ -1,7 +1,9 @@
 package com.xavelo.sqs.application.domain;
 
+import java.util.UUID;
+
 public record Quote(
-        String id,
+        UUID id,
         String quote,
         String song,
         String album,

--- a/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
@@ -14,6 +14,7 @@ import com.xavelo.sqs.port.out.UpdateQuotePort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, UpdateQuoteUseCase, ResetQuoteHitsUseCase, ResetQuotePostsUseCase {
@@ -46,7 +47,7 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
         for (Quote quote : quotes) {
             sqlBuilder.append(String.format(
                     "INSERT INTO quotes (id, quote, song, album, album_year, artist, hits, posts) VALUES ('%s', '%s', '%s', '%s', %d, '%s', %d, %d);\n",
-                    quote.id(),
+                    quote.id() != null ? quote.id().toString() : null,
                     quote.quote().replace("'", "''"),
                     quote.song().replace("'", "''"),
                     quote.album().replace("'", "''"),
@@ -60,7 +61,7 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
     }
 
     @Override
-    public void deleteQuote(String id) {
+    public void deleteQuote(UUID id) {
         deleteQuotePort.deleteQuote(id);
     }
 

--- a/application/src/main/java/com/xavelo/sqs/application/service/QuoteHelper.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/QuoteHelper.java
@@ -2,6 +2,8 @@ package com.xavelo.sqs.application.service;
 
 import com.xavelo.sqs.application.domain.Quote;
 
+import java.util.UUID;
+
 /**
  * Utility methods for manipulating {@link Quote} instances.
  */
@@ -33,7 +35,7 @@ public final class QuoteHelper {
     /**
      * Returns a copy of the given quote with the supplied id.
      */
-    public static Quote withId(Quote quote, String id) {
+    public static Quote withId(Quote quote, UUID id) {
         if (quote == null) {
             return null;
         }
@@ -53,7 +55,7 @@ public final class QuoteHelper {
     /**
      * Returns a copy of the given quote with the supplied id and spotify artist id
      */
-    public static Quote withSpotifyArtistId(Quote quote, String id, String spotifyArtistId) {
+    public static Quote withSpotifyArtistId(Quote quote, UUID id, String spotifyArtistId) {
         if (quote == null) {
             return null;
         }

--- a/application/src/main/java/com/xavelo/sqs/port/in/DeleteQuoteUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/DeleteQuoteUseCase.java
@@ -1,5 +1,7 @@
 package com.xavelo.sqs.port.in;
 
+import java.util.UUID;
+
 public interface DeleteQuoteUseCase {
-    void deleteQuote(String id);
+    void deleteQuote(UUID id);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/in/GetQuoteUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/GetQuoteUseCase.java
@@ -2,6 +2,8 @@ package com.xavelo.sqs.port.in;
 
 import com.xavelo.sqs.application.domain.Quote;
 
+import java.util.UUID;
+
 public interface GetQuoteUseCase {
-    Quote getQuote(String id);
+    Quote getQuote(UUID id);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/in/PatchQuoteUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/PatchQuoteUseCase.java
@@ -2,6 +2,8 @@ package com.xavelo.sqs.port.in;
 
 import com.xavelo.sqs.application.domain.Quote;
 
+import java.util.UUID;
+
 public interface PatchQuoteUseCase {
-    void patchQuote(String id, Quote quote);
+    void patchQuote(UUID id, Quote quote);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/in/StoreQuoteUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/StoreQuoteUseCase.java
@@ -3,8 +3,9 @@ package com.xavelo.sqs.port.in;
 import com.xavelo.sqs.application.domain.Quote;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface StoreQuoteUseCase {
-    String storeQuote(Quote quote);
-    List<String> storeQuotes(List<Quote> quotes);
+    UUID storeQuote(Quote quote);
+    List<UUID> storeQuotes(List<Quote> quotes);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/DeleteQuotePort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/DeleteQuotePort.java
@@ -1,5 +1,7 @@
 package com.xavelo.sqs.port.out;
 
+import java.util.UUID;
+
 public interface DeleteQuotePort {
-    void deleteQuote(String id);
+    void deleteQuote(UUID id);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/IncrementHitsPort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/IncrementHitsPort.java
@@ -1,5 +1,7 @@
 package com.xavelo.sqs.port.out;
 
+import java.util.UUID;
+
 public interface IncrementHitsPort {
-    void incrementHits(String id);
+    void incrementHits(UUID id);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/IncrementPostsPort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/IncrementPostsPort.java
@@ -1,5 +1,7 @@
 package com.xavelo.sqs.port.out;
 
+import java.util.UUID;
+
 public interface IncrementPostsPort {
-    void incrementPosts(String id);
+    void incrementPosts(UUID id);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/LoadQuotePort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/LoadQuotePort.java
@@ -1,12 +1,14 @@
 package com.xavelo.sqs.port.out;
 
 import com.xavelo.sqs.application.domain.Quote;
+
 import java.util.List;
+import java.util.UUID;
 
 public interface LoadQuotePort {
     List<Quote> loadQuotes();
 
-    Quote loadQuote(String id);
+    Quote loadQuote(UUID id);
 
     /**
      * Retrieve a random quote from the storage.

--- a/application/src/main/java/com/xavelo/sqs/port/out/MetricsPort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/MetricsPort.java
@@ -1,5 +1,7 @@
 package com.xavelo.sqs.port.out;
 
+import java.util.UUID;
+
 /**
  * Port for publishing application metrics.
  */
@@ -19,5 +21,5 @@ public interface MetricsPort {
      *
      * @param quoteId the identifier of the quote that was served
      */
-    void incrementQuoteHits(String quoteId);
+    void incrementQuoteHits(UUID quoteId);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/PatchQuotePort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/PatchQuotePort.java
@@ -2,6 +2,8 @@ package com.xavelo.sqs.port.out;
 
 import com.xavelo.sqs.application.domain.Quote;
 
+import java.util.UUID;
+
 public interface PatchQuotePort {
-    void patchQuote(String id, Quote quote);
+    void patchQuote(UUID id, Quote quote);
 }

--- a/application/src/main/java/com/xavelo/sqs/port/out/StoreQuotePort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/StoreQuotePort.java
@@ -4,8 +4,9 @@ import com.xavelo.sqs.application.domain.Artist;
 import com.xavelo.sqs.application.domain.Quote;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface StoreQuotePort {
-    String storeQuote(Quote quote, Artist artistMetadata);
-    List<String> storeQuotes(List<Quote> quotes);
+    UUID storeQuote(Quote quote, Artist artistMetadata);
+    List<UUID> storeQuotes(List<Quote> quotes);
 }

--- a/application/src/test/java/com/xavelo/sqs/adapter/in/http/quote/QuoteControllerTest.java
+++ b/application/src/test/java/com/xavelo/sqs/adapter/in/http/quote/QuoteControllerTest.java
@@ -42,7 +42,7 @@ class QuoteControllerTest {
 
     @Test
     void getQuotes() throws Exception {
-        List<Quote> quotes = List.of(new Quote(QUOTE_ID.toString(), "q", "s", "a", 1999, "art", 0, 0, null));
+        List<Quote> quotes = List.of(new Quote(QUOTE_ID, "q", "s", "a", 1999, "art", 0, 0, null));
         List<QuoteDto> dtos = List.of(new QuoteDto()
                 .id(QUOTE_ID)
                 .quote("q")
@@ -72,7 +72,7 @@ class QuoteControllerTest {
 
     @Test
     void getRandomQuoteFound() throws Exception {
-        Quote quote = new Quote(QUOTE_ID.toString(), "q", "s", "a", 1999, "art", 0, 0, null);
+        Quote quote = new Quote(QUOTE_ID, "q", "s", "a", 1999, "art", 0, 0, null);
         QuoteDto dto = new QuoteDto()
                 .id(QUOTE_ID)
                 .quote("q")
@@ -93,7 +93,7 @@ class QuoteControllerTest {
 
     @Test
     void getQuoteFound() throws Exception {
-        Quote quote = new Quote(QUOTE_ID.toString(), "q", "s", "a", 1999, "art", 0, 0, null);
+        Quote quote = new Quote(QUOTE_ID, "q", "s", "a", 1999, "art", 0, 0, null);
         QuoteDto dto = new QuoteDto()
                 .id(QUOTE_ID)
                 .quote("q")
@@ -104,7 +104,7 @@ class QuoteControllerTest {
                 .posts(0)
                 .hits(0)
                 .spotifyArtistId(null);
-        when(getQuoteUseCase.getQuote(QUOTE_ID.toString())).thenReturn(quote);
+        when(getQuoteUseCase.getQuote(QUOTE_ID)).thenReturn(quote);
         when(quoteMapper.toDto(quote)).thenReturn(dto);
 
         mockMvc.perform(get("/api/quote/" + QUOTE_ID))
@@ -114,7 +114,7 @@ class QuoteControllerTest {
 
     @Test
     void getQuoteNotFound() throws Exception {
-        when(getQuoteUseCase.getQuote(MISSING_QUOTE_ID.toString())).thenReturn(null);
+        when(getQuoteUseCase.getQuote(MISSING_QUOTE_ID)).thenReturn(null);
 
         mockMvc.perform(get("/api/quote/" + MISSING_QUOTE_ID))
                 .andExpect(status().isNotFound());
@@ -123,8 +123,8 @@ class QuoteControllerTest {
     @Test
     void getTop10Quotes() throws Exception {
         List<Quote> quotes = List.of(
-                new Quote("66666666-6666-6666-6666-666666666666", "q1", "s1", "a1", 2000, "art1", 100, 10, null),
-                new Quote("77777777-7777-7777-7777-777777777777", "q2", "s2", "a2", 2001, "art2", 90, 9, null)
+                new Quote(UUID.fromString("66666666-6666-6666-6666-666666666666"), "q1", "s1", "a1", 2000, "art1", 100, 10, null),
+                new Quote(UUID.fromString("77777777-7777-7777-7777-777777777777"), "q2", "s2", "a2", 2001, "art2", 90, 9, null)
         );
         List<QuoteDto> dtos = List.of(
                 new QuoteDto()

--- a/application/src/test/java/com/xavelo/sqs/application/service/QuoteEventRelayWorkerTest.java
+++ b/application/src/test/java/com/xavelo/sqs/application/service/QuoteEventRelayWorkerTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.UUID;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
@@ -24,7 +25,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class QuoteEventRelayWorkerTest {
 
-    private static final String QUOTE_ID = "33333333-3333-3333-3333-333333333333";
+    private static final UUID QUOTE_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
 
     @Mock
     private QuoteEventOutboxPort quoteEventOutboxPort;

--- a/application/src/test/java/com/xavelo/sqs/application/service/QuoteMetricsServiceTest.java
+++ b/application/src/test/java/com/xavelo/sqs/application/service/QuoteMetricsServiceTest.java
@@ -14,10 +14,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import java.util.UUID;
+
 @ExtendWith(MockitoExtension.class)
 class QuoteMetricsServiceTest {
 
-    private static final String QUOTE_ID = "44444444-4444-4444-4444-444444444444";
+    private static final UUID QUOTE_ID = UUID.fromString("44444444-4444-4444-4444-444444444444");
 
     @Mock
     private MetricsPort metricsPort;


### PR DESCRIPTION
## Summary
- switch the Quote domain record and its helper utilities to use `UUID` identifiers
- update service, adapter, and port layers to accept and return `UUID` values for quote operations
- adjust HTTP controllers, metrics adapter, persistence mapping, and associated tests to reflect the new identifier type

## Testing
- `./mvnw -pl application test` *(fails: Maven wrapper could not download dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e251f2642c83299475193cd9e32526