### PR TITLE
Handle artist metadata when storing multiple quotes

### DIFF
--- a/application/src/main/java/com/xavelo/sqs/port/out/StoreQuotePort.java
+++ b/application/src/main/java/com/xavelo/sqs/port/out/StoreQuotePort.java
@@ -8,5 +8,5 @@ import java.util.UUID;
 
 public interface StoreQuotePort {
     UUID storeQuote(Quote quote, Artist artistMetadata);
-    List<UUID> storeQuotes(List<Quote> quotes);
+    List<UUID> storeQuotes(List<Quote> quotes, List<Artist> artistsMetadata);
 }


### PR DESCRIPTION
## Summary
- fetch artist metadata for each quote when storing multiple quotes so spotify ids propagate to events
- persist spotify metadata during bulk quote storage in the MySQL adapter
- update the store quote port signature and unit tests for metadata-aware bulk storage

## Testing
- ./mvnw -q test *(fails: Network is unreachable while downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68e25735e71c8329967870887b9858b2