### PR TITLE
Switch admin export to JSON payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ All endpoints default to JSON and are served on port `8080`.
 | `PUT` | `/admin/quote/{id}` | Replace a quote (excluding restricted counters). |
 | `PATCH` | `/admin/quote/{id}` | Partially update a quote (excluding restricted counters). |
 | `DELETE` | `/admin/quote/{id}` | Delete a quote by id. |
-| `GET` | `/admin/export` | Export all quotes as SQL insert statements for backup or migration purposes. |
+| `GET` | `/admin/export` | Export all quotes as JSON objects ready to be sent to `POST /admin/quotes`. |
 
 ## Observability
 

--- a/api/src/main/resources/openapi/admin-api.yaml
+++ b/api/src/main/resources/openapi/admin-api.yaml
@@ -138,15 +138,17 @@ paths:
     get:
       tags:
         - Admin
-      summary: Export all quotes as SQL statements
+      summary: Export all quotes as JSON payloads
       operationId: exportQuotes
       responses:
         '200':
-          description: SQL export of all quotes
+          description: Export of all quotes formatted for POST /admin/quotes
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
+                type: array
+                items:
+                  $ref: './components/schemas.yaml#/components/schemas/Quote'
 components:
   schemas:
     Quote:

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/AdminController.java
@@ -118,9 +118,10 @@ public class AdminController implements AdminApi {
 
     @Override
     @CountAdapterInvocation(name = "export-quotes", direction = IN, type = HTTP)
-    public ResponseEntity<String> exportQuotes() {
-        String sql = adminService.exportQuotesAsSql();
-        return ResponseEntity.ok(sql);
+    public ResponseEntity<List<QuoteDto>> exportQuotes() {
+        List<Quote> quotes = adminService.exportQuotes();
+        List<QuoteDto> exportPayload = quoteMapper.toDto(quotes);
+        return ResponseEntity.ok(exportPayload);
     }
 
     @Override

--- a/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/mapper/AdminQuoteMapper.java
+++ b/application/src/main/java/com/xavelo/sqs/adapter/in/http/admin/mapper/AdminQuoteMapper.java
@@ -12,4 +12,8 @@ public interface AdminQuoteMapper {
     Quote toDomain(QuoteDto quoteDto);
 
     List<Quote> toDomain(List<QuoteDto> quoteDtos);
+
+    QuoteDto toDto(Quote quote);
+
+    List<QuoteDto> toDto(List<Quote> quotes);
 }

--- a/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
@@ -41,23 +41,10 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
     }
 
     @Override
-    public String exportQuotesAsSql() {
-        List<Quote> quotes = loadQuotePort.loadQuotes();
-        StringBuilder sqlBuilder = new StringBuilder();
-        for (Quote quote : quotes) {
-            sqlBuilder.append(String.format(
-                    "INSERT INTO quotes (id, quote, song, album, album_year, artist, hits, posts) VALUES ('%s', '%s', '%s', '%s', %d, '%s', %d, %d);\n",
-                    quote.id() != null ? quote.id().toString() : null,
-                    quote.quote().replace("'", "''"),
-                    quote.song().replace("'", "''"),
-                    quote.album().replace("'", "''"),
-                    quote.year(),
-                    quote.artist().replace("'", "''"),
-                    quote.hits(),
-                    quote.posts()
-            ));
-        }
-        return sqlBuilder.toString();
+    public List<Quote> exportQuotes() {
+        return loadQuotePort.loadQuotes().stream()
+                .map(QuoteHelper::sanitize)
+                .toList();
     }
 
     @Override

--- a/application/src/main/java/com/xavelo/sqs/port/in/ExportQuotesUseCase.java
+++ b/application/src/main/java/com/xavelo/sqs/port/in/ExportQuotesUseCase.java
@@ -1,5 +1,5 @@
 package com.xavelo.sqs.port.in;
 
 public interface ExportQuotesUseCase {
-    String exportQuotesAsSql();
+    java.util.List<com.xavelo.sqs.application.domain.Quote> exportQuotes();
 }


### PR DESCRIPTION
## Summary
- return JSON export payloads from the /admin/export endpoint so they can be reused with POST /admin/quotes
- add mapper support for turning domain quotes into API DTOs and sanitize exports in the service layer
- refresh the OpenAPI specification and README description to document the new JSON export format

## Testing
- ./mvnw -pl application -DskipTests compile *(fails: Maven wrapper cannot download distribution in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e276dcd8e48329a604999bfb96acc6