### PR TITLE
Remove restricted fields from admin export response

### DIFF
--- a/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/AdminService.java
@@ -43,7 +43,7 @@ public class AdminService implements ExportQuotesUseCase, DeleteQuoteUseCase, Up
     @Override
     public List<Quote> exportQuotes() {
         return loadQuotePort.loadQuotes().stream()
-                .map(QuoteHelper::sanitize)
+                .map(QuoteHelper::sanitizeForExport)
                 .toList();
     }
 

--- a/application/src/main/java/com/xavelo/sqs/application/service/QuoteHelper.java
+++ b/application/src/main/java/com/xavelo/sqs/application/service/QuoteHelper.java
@@ -33,6 +33,26 @@ public final class QuoteHelper {
     }
 
     /**
+     * Returns a copy of the given quote without attributes that should not be exported.
+     */
+    public static Quote sanitizeForExport(Quote quote) {
+        if (quote == null) {
+            return null;
+        }
+        return new Quote(
+                null,
+                quote.quote(),
+                quote.song(),
+                quote.album(),
+                quote.year(),
+                quote.artist(),
+                null,
+                null,
+                null
+        );
+    }
+
+    /**
      * Returns a copy of the given quote with the supplied id.
      */
     public static Quote withId(Quote quote, UUID id) {

--- a/application/src/test/java/com/xavelo/sqs/application/service/QuoteHelperTest.java
+++ b/application/src/test/java/com/xavelo/sqs/application/service/QuoteHelperTest.java
@@ -1,0 +1,34 @@
+package com.xavelo.sqs.application.service;
+
+import com.xavelo.sqs.application.domain.Quote;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QuoteHelperTest {
+
+    @Test
+    void sanitizeForExportRemovesRestrictedFieldsWhileKeepingContent() {
+        UUID id = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        Quote quote = new Quote(id, "quote", "song", "album", 1999, "artist", 5, 7, "spotify-id");
+
+        Quote sanitized = QuoteHelper.sanitizeForExport(quote);
+
+        assertNull(sanitized.id());
+        assertNull(sanitized.posts());
+        assertNull(sanitized.hits());
+        assertNull(sanitized.spotifyArtistId());
+        assertEquals("quote", sanitized.quote());
+        assertEquals("song", sanitized.song());
+        assertEquals("album", sanitized.album());
+        assertEquals(1999, sanitized.year());
+        assertEquals("artist", sanitized.artist());
+    }
+
+    @Test
+    void sanitizeForExportReturnsNullWhenQuoteIsNull() {
+        assertNull(QuoteHelper.sanitizeForExport(null));
+    }
+}


### PR DESCRIPTION
## Summary
- remove restricted fields when exporting quotes through the admin endpoint
- add helper utility for export sanitization with unit coverage

## Testing
- ./mvnw -pl application test *(fails: network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e2afcdb3608329b93bdf2e6cae0a45